### PR TITLE
Added direction arguments for geodesy project

### DIFF
--- a/src/main/java/pl/kosma/geodesy/DirectionArgumentType.java
+++ b/src/main/java/pl/kosma/geodesy/DirectionArgumentType.java
@@ -1,0 +1,20 @@
+package pl.kosma.geodesy;
+
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.command.argument.EnumArgumentType;
+import net.minecraft.util.math.Direction;
+
+public class DirectionArgumentType extends EnumArgumentType<Direction> {
+
+    private DirectionArgumentType() {
+        super(Direction.CODEC, Direction::values);
+    }
+
+    public static DirectionArgumentType direction() {
+        return new DirectionArgumentType();
+    }
+
+    public static Direction getDirection(CommandContext<?> context, String id) {
+        return context.getArgument(id, Direction.class);
+    }
+}

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -145,8 +145,8 @@ public class GeodesyCore {
         geodesyProject(new Direction[]{Direction.SOUTH});
         geodesyProject(new Direction[]{Direction.UP});
         geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH});
+        geodesyProject(new Direction[]{Direction.EAST, Direction.UP});
         geodesyProject(new Direction[]{Direction.SOUTH, Direction.UP});
-        geodesyProject(new Direction[]{Direction.UP, Direction.EAST});
         geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH, Direction.UP});
         // Clean up the results of the last projection.
         geodesyProject(null);


### PR DESCRIPTION
I noticed in the command /geodesy project <directions> that there are no suggestions for the directions. So I added it.
Also, the order of the inputted directions is still retained.
Changed analyze command to always project up direction last.