### PR TITLE
Faster detect, analyze, and project geode

### DIFF
--- a/src/main/java/pl/kosma/geodesy/IterableBlockBox.java
+++ b/src/main/java/pl/kosma/geodesy/IterableBlockBox.java
@@ -98,7 +98,7 @@ class IterableBlockBox extends BlockBox {
     }
 
     // Backported from 1.18 because in 1.17 this function mutates state.
-    public BlockBox expand(int offset) {
-        return new BlockBox(this.getMinX() - offset, this.getMinY() - offset, this.getMinZ() - offset, this.getMaxX() + offset, this.getMaxY() + offset, this.getMaxZ() + offset);
+    public IterableBlockBox expand(int offset) {
+        return new IterableBlockBox(this.getMinX() - offset, this.getMinY() - offset, this.getMinZ() - offset, this.getMaxX() + offset, this.getMaxY() + offset, this.getMaxZ() + offset);
     }
 }


### PR DESCRIPTION
Store all budding amethyst and amethyst cluster positions in `geodesyArea`
- `detectDeode`: loop over all Budding Amethysts only once instead of twice
- `projectGeode`: loops over Budding Amethysts or Amethyst Clusters instead of all blocks
- `geodesyAnalyze`: benefits from `projectGeode`

Also, helpful feedback when calling `/geodesy analyze`, `/geodesy project`, or `/geodesy assembly` before calling `/geodesy area`

Note: depends on lists `buddingAmethystPositions` and `amethystClusterPositions` to contain positions for all Budding Amethysts and Amethyst Cluster respectively.

Should be no-compromise
I have already tested and its faster but please test to make sure