### PR TITLE
feat: added parallel face solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,31 +83,65 @@ Here I run `/geodesy project east south up`:
 
 ![Projection done.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode4.png)
 
-### Step 5: Sticky blocks
+### Step 5: Solve (Optional)
 
-Place the slime and honey blocks outside the structure, as shown by ilmango in the video.
-All pumpkin blocks should be covered; no crying obsidian blocks should be covered. If you
-can't cover all pumpkin blocks, the efficiency of the farm will be slightly reduced.
+Run `/geodesy solve` to automatically calculate optimal placement of slime and honey
+blocks, as well as the mob head markers for flying machines. This step is optional -
+you can still place them manually as described in Steps 6 and 7.
+
+The solver uses a backtracking algorithm to find "islands" (connected groups of sticky
+blocks) that maximize coverage of pumpkin blocks while respecting constraints:
+
+* Each island must be 4-12 blocks in size
+* Each island must contain an L-shape (required for flying machine mechanics)
+* Adjacent islands use alternating materials (slime vs honey) to prevent sticking
+* Islands cannot overlap or cover crying obsidian (blocked) cells
+
+The command accepts optional parameters:
+
+* `/geodesy solve` - Use default settings (5 second timeout, cost of 1.0)
+* `/geodesy solve (timeout)` - Set timeout in seconds (1-300)
+* `/geodesy solve (timeout) (cost)` - Set timeout and cost threshold (1.0-12.0)
+
+The **cost** parameter controls the tradeoff between coverage and number of flying machines:
+
+* Lower cost (e.g. 1.0): More islands/machines, higher harvest coverage
+* Higher cost (e.g. 4.0): Fewer islands/machines, may sacrifice some coverage
+
+The solver scores solutions as: `harvest_cells_covered - (island_count × cost)`
+
+After solving, slime/honey blocks are placed one layer outside the wall, and mob head
+markers (3 zombie heads + 1 wither skeleton skull in an L-shape) are placed for each island.
+
+You can re-run `/geodesy solve` with different parameters - the previous solution will
+be cleared automatically.
+
+### Step 6: Sticky blocks (Manual Alternative)
+
+If you prefer manual placement or want to adjust the solver's output, place slime and
+honey blocks outside the structure, as shown by ilmango in the video. All pumpkin blocks
+should be covered; no crying obsidian blocks should be covered. If you can't cover all
+pumpkin blocks, the efficiency of the farm will be slightly reduced.
 
 ![Sticky block structures placed.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode5.png)
 
-### Step 6: Marker blocks
+### Step 7: Marker blocks (Manual Alternative)
 
-Using the supplied mob heads, place markers to indicate where the flying machines
-should go. Black mob head markes a blocker obsidian block, three green mob heads
-indicate a flying machine.
+If you skipped the solve step or want to adjust markers, use mob heads to indicate where
+the flying machines should go. Black mob head (wither skeleton skull) marks a blocker
+obsidian block, three green mob heads (zombie heads) indicate a flying machine.
 
 ![Flying machine markers placed.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode6.png)
 
-### Step 7: Assemble
+### Step 8: Assemble
 
 Run `/geodesy assemble` to "push" the sticky block structures inside the obsidian frame
-and generate flying machines at locations that you marked. The redstone clock is also 
+and generate flying machines at locations that you marked. The redstone clock is also
 generated for your convenience - just connect it.
 
 ![Assembled farm structure.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode7.png)
 
-### Step 8: Wiring
+### Step 9: Wiring
 
 The rest is up to you! Add trigger wiring and collection system. When adding repeaters to the trigger
 wiring, make sure to set them to maximum delay.  Again, watch ilmango's video for more information.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here I run `/geodesy project east south up`:
 
 ![Projection done.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode4.png)
 
-### Step 5: Solve (Optional)
+### Steps 5-6: Solve (Automatic Alternative)
 
 Run `/geodesy solve` to automatically calculate optimal placement of slime and honey
 blocks, as well as the mob head markers for flying machines. This step is optional -
@@ -99,9 +99,9 @@ blocks) that maximize coverage of pumpkin blocks while respecting constraints:
 
 The command accepts optional parameters:
 
-* `/geodesy solve` - Use default settings (5 second timeout, cost of 1.0)
-* `/geodesy solve (timeout)` - Set timeout in seconds (1-300)
-* `/geodesy solve (timeout) (cost)` - Set timeout and cost threshold (1.0-12.0)
+* `/geodesy solve` - Use default settings (cost of 1.0, 5 second timeout)
+* `/geodesy solve (cost)` - Set cost threshold (1.0-12.0)
+* `/geodesy solve (cost) (timeout)` - Set cost threshold and timeout in seconds (1-300)
 
 The **cost** parameter controls the tradeoff between coverage and number of flying machines:
 
@@ -116,7 +116,7 @@ markers (3 zombie heads + 1 wither skeleton skull in an L-shape) are placed for 
 You can re-run `/geodesy solve` with different parameters - the previous solution will
 be cleared automatically.
 
-### Step 6: Sticky blocks (Manual Alternative)
+### Step 5: Sticky blocks (Manual Alternative)
 
 If you prefer manual placement or want to adjust the solver's output, place slime and
 honey blocks outside the structure, as shown by ilmango in the video. All pumpkin blocks
@@ -125,7 +125,7 @@ pumpkin blocks, the efficiency of the farm will be slightly reduced.
 
 ![Sticky block structures placed.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode5.png)
 
-### Step 7: Marker blocks (Manual Alternative)
+### Step 6: Marker blocks (Manual Alternative)
 
 If you skipped the solve step or want to adjust markers, use mob heads to indicate where
 the flying machines should go. Black mob head (wither skeleton skull) marks a blocker
@@ -133,7 +133,7 @@ obsidian block, three green mob heads (zombie heads) indicate a flying machine.
 
 ![Flying machine markers placed.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode6.png)
 
-### Step 8: Assemble
+### Step 7: Assemble
 
 Run `/geodesy assemble` to "push" the sticky block structures inside the obsidian frame
 and generate flying machines at locations that you marked. The redstone clock is also
@@ -141,7 +141,7 @@ generated for your convenience - just connect it.
 
 ![Assembled farm structure.](https://raw.githubusercontent.com/kosma/geodesy-fabric/master/assets/geode7.png)
 
-### Step 9: Wiring
+### Step 8: Wiring
 
 The rest is up to you! Add trigger wiring and collection system. When adding repeaters to the trigger
 wiring, make sure to set them to maximum delay.  Again, watch ilmango's video for more information.

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -17,6 +17,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
 import net.minecraft.util.Pair;
+import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -32,14 +33,11 @@ import pl.kosma.geodesy.solver.SolverResult;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -189,6 +187,318 @@ public class GeodesyCore {
         sendCommandFeedback("Now run /geodesy project with your chosen projections.");
     }
 
+    // Solve for optimal slime/honey block placement. Must be run after /geodesy project.
+    void geodesySolve() {
+        geodesySolve(SolverConfig.defaults());
+    }
+
+    // Solve for optimal slime/honey block placement. Each face is solved in parallel.
+    void geodesySolve(SolverConfig config) {
+        sendCommandFeedback("---");
+
+        // Validate that we have the required state.
+        if (geode == null) {
+            sendCommandFeedback("No geode detected. Run /geodesy area first.");
+            return;
+        }
+        if (lastProjectedDirections == null || lastProjectedDirections.length == 0) {
+            sendCommandFeedback("No projection found. Run /geodesy project first.");
+            return;
+        }
+
+        // Clear any previous solver results (sticky blocks and mob heads)
+        for (Direction direction : lastProjectedDirections) {
+            clearSolverLayers(direction);
+        }
+
+        String directionNames = Arrays.stream(lastProjectedDirections).map(Direction::toString).collect(Collectors.joining(", "));
+        sendCommandFeedback("Solving %d face(s) in parallel: %s...", lastProjectedDirections.length, directionNames);
+
+        // Extract all face grids first (must be done on main thread for world access)
+        Map<Direction, FaceGrid> faceGrids = new LinkedHashMap<>();
+        for (Direction direction : lastProjectedDirections) {
+            FaceGrid faceGrid = extractFaceGrid(direction);
+            if (faceGrid != null) {
+                faceGrids.put(direction, faceGrid);
+            } else {
+                sendCommandFeedback("  %s: Failed to extract face grid.", direction);
+            }
+        }
+
+        if (faceGrids.isEmpty()) {
+            sendCommandFeedback("No faces to solve.");
+            return;
+        }
+
+        // Submit all solve tasks in parallel using Minecraft's shared worker pool
+        Map<Direction, CompletableFuture<SolverResult>> futures = new LinkedHashMap<>();
+        for (Map.Entry<Direction, FaceGrid> entry : faceGrids.entrySet()) {
+            Direction direction = entry.getKey();
+            FaceGrid faceGrid = entry.getValue();
+
+            // Create a new solver instance for each face (thread safety)
+            CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(
+                    () -> new IslandFaceSolver().solve(faceGrid, config), Util.getMainWorkerExecutor());
+
+            futures.put(direction, future);
+        }
+
+        // Wait for all solves to complete and apply results
+        // Results are applied sequentially to ensure thread-safe world modifications
+        for (Map.Entry<Direction, CompletableFuture<SolverResult>> entry : futures.entrySet()) {
+            Direction direction = entry.getKey();
+            try {
+                SolverResult result = entry.getValue().join();
+
+                // Apply the solution to the world (must be on main thread)
+                applySolverResult(direction, result);
+
+                // Report results
+                sendCommandFeedback("  %s: %.0f%% coverage (%d/%d), %d blocks, %dms%s",
+                        direction,
+                        result.getCoveragePercent(),
+                        result.getHarvestCovered(),
+                        result.getTotalHarvest(),
+                        result.getBlockCount(),
+                        result.getSolveTimeMs(),
+                        result.isTimedOut() ? " (timed out)" : "");
+            } catch (Exception e) {
+                LOGGER.error("Failed to solve face {}", direction, e);
+                sendCommandFeedback("  %s: Failed to solve - %s", direction, e.getMessage());
+            }
+        }
+
+        sendCommandFeedback("Solve complete. Run /geodesy assemble when ready.");
+    }
+
+    // Clears sticky blocks and mob heads for a face. Allows re-running /geodesy solve.
+    private void clearSolverLayers(Direction direction) {
+        if (geode == null) return;
+
+        // Calculate grid dimensions based on the direction
+        int width, height;
+        switch (direction.getAxis()) {
+            case X -> {
+                width = geode.getMaxZ() - geode.getMinZ() + 1;
+                height = geode.getMaxY() - geode.getMinY() + 1;
+            }
+            case Y -> {
+                width = geode.getMaxX() - geode.getMinX() + 1;
+                height = geode.getMaxZ() - geode.getMinZ() + 1;
+            }
+            case Z -> {
+                width = geode.getMaxX() - geode.getMinX() + 1;
+                height = geode.getMaxY() - geode.getMinY() + 1;
+            }
+            default -> {
+                return;
+            }
+        }
+
+        // Clear both layers (wall+1 for sticky blocks, wall+2 for mob heads)
+        BlockPos.Mutable mutablePos = new BlockPos.Mutable();
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                BlockPos wallPos = gridToWallPos(direction, x, y);
+
+                // Clear sticky block layer (wall + 1)
+                mutablePos.set(wallPos).move(direction, 1);
+                Block stickyBlock = world.getBlockState(mutablePos).getBlock();
+                if (STICKY_BLOCKS.contains(stickyBlock)) {
+                    world.setBlockState(mutablePos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
+                }
+
+                // Clear mob head layer (wall + 2)
+                mutablePos.set(wallPos).move(direction, 2);
+                Block headBlock = world.getBlockState(mutablePos).getBlock();
+                if (MARKERS_BLOCKER.contains(headBlock) || MARKERS_MACHINE.contains(headBlock)) {
+                    world.setBlockState(mutablePos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
+                }
+            }
+        }
+    }
+
+    // Extracts a FaceGrid from the world. Reads wall blocks placed by /geodesy project.
+    @Nullable
+    private FaceGrid extractFaceGrid(Direction direction) {
+        if (geode == null) return null;
+
+        // Calculate grid dimensions based on the direction.
+        // For each direction, we need to map the wall to a 2D grid.
+        int width, height;
+        switch (direction.getAxis()) {
+            case X -> {
+                // East/West face: Z is width, Y is height
+                width = geode.getMaxZ() - geode.getMinZ() + 1;
+                height = geode.getMaxY() - geode.getMinY() + 1;
+            }
+            case Y -> {
+                // Up/Down face: X is width, Z is height
+                width = geode.getMaxX() - geode.getMinX() + 1;
+                height = geode.getMaxZ() - geode.getMinZ() + 1;
+            }
+            case Z -> {
+                // North/South face: X is width, Y is height
+                width = geode.getMaxX() - geode.getMinX() + 1;
+                height = geode.getMaxY() - geode.getMinY() + 1;
+            }
+            default -> {
+                return null;
+            }
+        }
+
+        FaceGrid grid = new FaceGrid(width, height, direction);
+
+        // Iterate through the wall and populate the grid.
+        BlockPos.Mutable mutablePos = new BlockPos.Mutable();
+        for (int w = 0; w < width; w++) {
+            for (int h = 0; h < height; h++) {
+                setMutableToWallPos(mutablePos, direction, w, h);
+                Block block = world.getBlockState(mutablePos).getBlock();
+
+                byte cellValue;
+                if (block == Blocks.CRYING_OBSIDIAN) {
+                    cellValue = FaceGrid.CELL_BLOCKED;
+                } else if (block == Blocks.PUMPKIN) {
+                    cellValue = FaceGrid.CELL_HARVEST;
+                } else {
+                    cellValue = FaceGrid.CELL_AIR;
+                }
+                grid.setCell(w, h, cellValue);
+            }
+        }
+
+        return grid;
+    }
+
+    // Converts grid coordinates to world wall position.
+    private BlockPos gridToWallPos(Direction direction, int gridX, int gridY) {
+        return switch (direction) {
+            case EAST -> new BlockPos(
+                    geode.getMaxX() + WALL_OFFSET,
+                    geode.getMinY() + gridY,
+                    geode.getMinZ() + gridX);
+            case WEST -> new BlockPos(
+                    geode.getMinX() - WALL_OFFSET,
+                    geode.getMinY() + gridY,
+                    geode.getMinZ() + gridX);
+            case UP -> new BlockPos(
+                    geode.getMinX() + gridX,
+                    geode.getMaxY() + WALL_OFFSET,
+                    geode.getMinZ() + gridY);
+            case DOWN -> new BlockPos(
+                    geode.getMinX() + gridX,
+                    geode.getMinY() - WALL_OFFSET,
+                    geode.getMinZ() + gridY);
+            case SOUTH -> new BlockPos(
+                    geode.getMinX() + gridX,
+                    geode.getMinY() + gridY,
+                    geode.getMaxZ() + WALL_OFFSET);
+            case NORTH -> new BlockPos(
+                    geode.getMinX() + gridX,
+                    geode.getMinY() + gridY,
+                    geode.getMinZ() - WALL_OFFSET);
+        };
+    }
+
+    // Sets a mutable BlockPos to the wall position for given grid coordinates.
+    private void setMutableToWallPos(BlockPos.Mutable pos, Direction direction, int gridX, int gridY) {
+        switch (direction) {
+            case EAST -> pos.set(geode.getMaxX() + WALL_OFFSET, geode.getMinY() + gridY, geode.getMinZ() + gridX);
+            case WEST -> pos.set(geode.getMinX() - WALL_OFFSET, geode.getMinY() + gridY, geode.getMinZ() + gridX);
+            case UP -> pos.set(geode.getMinX() + gridX, geode.getMaxY() + WALL_OFFSET, geode.getMinZ() + gridY);
+            case DOWN -> pos.set(geode.getMinX() + gridX, geode.getMinY() - WALL_OFFSET, geode.getMinZ() + gridY);
+            case SOUTH -> pos.set(geode.getMinX() + gridX, geode.getMinY() + gridY, geode.getMaxZ() + WALL_OFFSET);
+            case NORTH -> pos.set(geode.getMinX() + gridX, geode.getMinY() + gridY, geode.getMinZ() - WALL_OFFSET);
+        }
+    }
+
+    // Applies solver result: places slime/honey blocks and mob heads.
+    private void applySolverResult(Direction direction, SolverResult result) {
+        // Place sticky blocks for each cell
+        for (int x = 0; x < result.getWidth(); x++) {
+            for (int y = 0; y < result.getHeight(); y++) {
+                SolverResult.PlacementType placement = result.getPlacement(x, y);
+                if (placement == SolverResult.PlacementType.NONE) {
+                    continue;
+                }
+
+                // Calculate the position one block outside the wall (where sticky blocks go).
+                BlockPos wallPos = gridToWallPos(direction, x, y);
+                BlockPos placementPos = wallPos.offset(direction, 1);
+
+                Block blockToPlace = switch (placement) {
+                    case SLIME -> Blocks.SLIME_BLOCK;
+                    case HONEY -> Blocks.HONEY_BLOCK;
+                    default -> null;
+                };
+
+                if (blockToPlace != null) {
+                    world.setBlockState(placementPos, blockToPlace.getDefaultState(), NOTIFY_LISTENERS);
+                }
+            }
+        }
+
+        // Place mob heads for each island
+        for (SolverResult.Island island : result.getIslands()) {
+            placeMobHeadsForIsland(direction, island);
+        }
+    }
+
+    // Places mob heads in L-shape pattern: 3 zombie heads + 1 wither skeleton skull.
+    // Uses the pre-computed L-shape data from the solver result.
+    private void placeMobHeadsForIsland(Direction direction, SolverResult.Island island) {
+        Set<int[]> lShapeCells = island.getLShapeCells();
+        if (lShapeCells == null || lShapeCells.size() != 4) return;
+
+        // The L-shape cells are [x, y] pairs. We need to identify the stem (3 in a row)
+        // and the corner (1 perpendicular). Find the stem by looking for 3 collinear cells.
+        int[][] cellArray = lShapeCells.toArray(new int[0][]);
+
+        // Find which cell is the corner: the one not collinear with the other three.
+        // A corner cell shares neither row nor column with all other cells in a line.
+        int cornerIdx = -1;
+        for (int i = 0; i < 4; i++) {
+            // Check if removing this cell leaves 3 collinear cells
+            int[] others = new int[3];
+            int idx = 0;
+            for (int j = 0; j < 4; j++) {
+                if (j != i) others[idx++] = j;
+            }
+            // 3 cells are collinear if they share the same x or same y
+            boolean sameX = cellArray[others[0]][0] == cellArray[others[1]][0] && cellArray[others[1]][0] == cellArray[others[2]][0];
+            boolean sameY = cellArray[others[0]][1] == cellArray[others[1]][1] && cellArray[others[1]][1] == cellArray[others[2]][1];
+            if (sameX || sameY) {
+                cornerIdx = i;
+                break;
+            }
+        }
+
+        if (cornerIdx == -1) return;
+
+        // Place zombie heads on stem cells, wither skeleton skull on corner
+        for (int i = 0; i < 4; i++) {
+            BlockPos headPos = gridToWallPos(direction, cellArray[i][0], cellArray[i][1]).offset(direction, 2);
+            if (i == cornerIdx) {
+                placeSkull(headPos, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, direction);
+            } else {
+                placeSkull(headPos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
+            }
+        }
+    }
+
+    // Places a skull: wall variant for horizontal faces, floor variant for up/down.
+    private void placeSkull(BlockPos pos, Block floorVariant, Block wallVariant, Direction faceDirection) {
+        if (faceDirection == Direction.UP || faceDirection == Direction.DOWN) {
+            // Floor variant for up/down faces
+            world.setBlockState(pos, floorVariant.getDefaultState(), NOTIFY_LISTENERS);
+        } else {
+            // Wall variant for horizontal faces
+            world.setBlockState(pos, wallVariant.getDefaultState()
+                    .with(net.minecraft.state.property.Properties.HORIZONTAL_FACING, faceDirection.getOpposite()), NOTIFY_LISTENERS);
+        }
+    }
+
     void geodesyAssemble() {
         // Return if geodesy area has not been run yet.
         if (geode == null) {
@@ -285,361 +595,6 @@ public class GeodesyCore {
 
         // Generate the water collection system.
         WaterCollectionSystemGenerator.generate(world, geode.expand(WALL_OFFSET - 1));
-    }
-
-    // Solve for optimal slime/honey block placement. Must be run after /geodesy project.
-    void geodesySolve() {
-        geodesySolve(SolverConfig.defaults());
-    }
-
-    // Solve for optimal slime/honey block placement. Each face is solved in parallel.
-    void geodesySolve(SolverConfig config) {
-        sendCommandFeedback("---");
-
-        // Validate that we have the required state.
-        if (geode == null) {
-            sendCommandFeedback("No geode detected. Run /geodesy area first.");
-            return;
-        }
-        if (lastProjectedDirections == null || lastProjectedDirections.length == 0) {
-            sendCommandFeedback("No projection found. Run /geodesy project first.");
-            return;
-        }
-
-        // Clear any previous solver results (sticky blocks and mob heads)
-        for (Direction direction : lastProjectedDirections) {
-            clearSolverLayers(direction);
-        }
-
-        sendCommandFeedback("Solving %d face(s) in parallel...", lastProjectedDirections.length);
-
-        // Extract all face grids first (must be done on main thread for world access)
-        Map<Direction, FaceGrid> faceGrids = new LinkedHashMap<>();
-        for (Direction direction : lastProjectedDirections) {
-            FaceGrid faceGrid = extractFaceGrid(direction);
-            if (faceGrid != null) {
-                faceGrids.put(direction, faceGrid);
-            } else {
-                sendCommandFeedback("  %s: Failed to extract face grid.", direction);
-            }
-        }
-
-        if (faceGrids.isEmpty()) {
-            sendCommandFeedback("No faces to solve.");
-            return;
-        }
-
-        // Create a thread pool sized appropriately for the workload
-        int threadCount = Math.min(faceGrids.size(), Runtime.getRuntime().availableProcessors());
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-        try {
-            // Submit all solve tasks in parallel
-            Map<Direction, CompletableFuture<SolverResult>> futures = new LinkedHashMap<>();
-            for (Map.Entry<Direction, FaceGrid> entry : faceGrids.entrySet()) {
-                Direction direction = entry.getKey();
-                FaceGrid faceGrid = entry.getValue();
-
-                // Create a new solver instance for each face (thread safety)
-                CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(
-                        () -> new IslandFaceSolver().solve(faceGrid, config), executor);
-
-                futures.put(direction, future);
-            }
-
-            // Wait for all solves to complete and apply results
-            // Results are applied sequentially to ensure thread-safe world modifications
-            for (Map.Entry<Direction, CompletableFuture<SolverResult>> entry : futures.entrySet()) {
-                Direction direction = entry.getKey();
-                try {
-                    SolverResult result = entry.getValue().join();
-
-                    // Apply the solution to the world (must be on main thread)
-                    applySolverResult(direction, result);
-
-                    // Report results
-                    sendCommandFeedback("  %s: %.0f%% coverage (%d/%d), %d blocks, %dms%s",
-                            direction,
-                            result.getCoveragePercent(),
-                            result.getHarvestCovered(),
-                            result.getTotalHarvest(),
-                            result.getBlockCount(),
-                            result.getSolveTimeMs(),
-                            result.isTimedOut() ? " (timed out)" : "");
-                } catch (Exception e) {
-                    LOGGER.error("Failed to solve face {}", direction, e);
-                    sendCommandFeedback("  %s: Failed to solve - %s", direction, e.getMessage());
-                }
-            }
-        } finally {
-            // Always shut down the executor to prevent resource leaks
-            executor.shutdown();
-        }
-
-        sendCommandFeedback("Solve complete. Run /geodesy assemble when ready.");
-    }
-
-    // Clears sticky blocks and mob heads for a face. Allows re-running /geodesy solve.
-    private void clearSolverLayers(Direction direction) {
-        if (geode == null) return;
-
-        // Calculate grid dimensions based on the direction
-        int width, height;
-        switch (direction.getAxis()) {
-            case X -> {
-                width = geode.getMaxZ() - geode.getMinZ() + 1;
-                height = geode.getMaxY() - geode.getMinY() + 1;
-            }
-            case Y -> {
-                width = geode.getMaxX() - geode.getMinX() + 1;
-                height = geode.getMaxZ() - geode.getMinZ() + 1;
-            }
-            case Z -> {
-                width = geode.getMaxX() - geode.getMinX() + 1;
-                height = geode.getMaxY() - geode.getMinY() + 1;
-            }
-            default -> {
-                return;
-            }
-        }
-
-        // Clear both layers (wall+1 for sticky blocks, wall+2 for mob heads)
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                BlockPos wallPos = gridToWallPos(direction, x, y);
-
-                // Clear sticky block layer (wall + 1)
-                BlockPos stickyPos = wallPos.offset(direction, 1);
-                Block stickyBlock = world.getBlockState(stickyPos).getBlock();
-                if (STICKY_BLOCKS.contains(stickyBlock)) {
-                    world.setBlockState(stickyPos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
-                }
-
-                // Clear mob head layer (wall + 2)
-                BlockPos headPos = wallPos.offset(direction, 2);
-                Block headBlock = world.getBlockState(headPos).getBlock();
-                if (MARKERS_BLOCKER.contains(headBlock) || MARKERS_MACHINE.contains(headBlock)) {
-                    world.setBlockState(headPos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
-                }
-            }
-        }
-    }
-
-    // Extracts a FaceGrid from the world. Reads wall blocks placed by /geodesy project.
-    @Nullable
-    private FaceGrid extractFaceGrid(Direction direction) {
-        if (geode == null) return null;
-
-        // Calculate grid dimensions based on the direction.
-        // For each direction, we need to map the wall to a 2D grid.
-        int width, height;
-        switch (direction.getAxis()) {
-            case X -> {
-                // East/West face: Z is width, Y is height
-                width = geode.getMaxZ() - geode.getMinZ() + 1;
-                height = geode.getMaxY() - geode.getMinY() + 1;
-            }
-            case Y -> {
-                // Up/Down face: X is width, Z is height
-                width = geode.getMaxX() - geode.getMinX() + 1;
-                height = geode.getMaxZ() - geode.getMinZ() + 1;
-            }
-            case Z -> {
-                // North/South face: X is width, Y is height
-                width = geode.getMaxX() - geode.getMinX() + 1;
-                height = geode.getMaxY() - geode.getMinY() + 1;
-            }
-            default -> {
-                return null;
-            }
-        }
-
-        FaceGrid grid = new FaceGrid(width, height, direction);
-
-        // Iterate through the wall and populate the grid.
-        for (int w = 0; w < width; w++) {
-            for (int h = 0; h < height; h++) {
-                BlockPos wallPos = gridToWallPos(direction, w, h);
-                Block block = world.getBlockState(wallPos).getBlock();
-
-                int cellValue;
-                if (block == Blocks.CRYING_OBSIDIAN) {
-                    cellValue = FaceGrid.CELL_BLOCKED;
-                } else if (block == Blocks.PUMPKIN) {
-                    cellValue = FaceGrid.CELL_HARVEST;
-                } else {
-                    cellValue = FaceGrid.CELL_AIR;
-                }
-                grid.setCell(w, h, cellValue);
-            }
-        }
-
-        return grid;
-    }
-
-    // Converts grid coordinates to world wall position.
-    private BlockPos gridToWallPos(Direction direction, int gridX, int gridY) {
-        return switch (direction) {
-            case EAST -> new BlockPos(
-                    geode.getMaxX() + WALL_OFFSET,
-                    geode.getMinY() + gridY,
-                    geode.getMinZ() + gridX);
-            case WEST -> new BlockPos(
-                    geode.getMinX() - WALL_OFFSET,
-                    geode.getMinY() + gridY,
-                    geode.getMinZ() + gridX);
-            case UP -> new BlockPos(
-                    geode.getMinX() + gridX,
-                    geode.getMaxY() + WALL_OFFSET,
-                    geode.getMinZ() + gridY);
-            case DOWN -> new BlockPos(
-                    geode.getMinX() + gridX,
-                    geode.getMinY() - WALL_OFFSET,
-                    geode.getMinZ() + gridY);
-            case SOUTH -> new BlockPos(
-                    geode.getMinX() + gridX,
-                    geode.getMinY() + gridY,
-                    geode.getMaxZ() + WALL_OFFSET);
-            case NORTH -> new BlockPos(
-                    geode.getMinX() + gridX,
-                    geode.getMinY() + gridY,
-                    geode.getMinZ() - WALL_OFFSET);
-        };
-    }
-
-    // Applies solver result: places slime/honey blocks and mob heads.
-    private void applySolverResult(Direction direction, SolverResult result) {
-        // Place sticky blocks for each cell
-        for (int x = 0; x < result.getWidth(); x++) {
-            for (int y = 0; y < result.getHeight(); y++) {
-                SolverResult.PlacementType placement = result.getPlacement(x, y);
-                if (placement == SolverResult.PlacementType.NONE) {
-                    continue;
-                }
-
-                // Calculate the position one block outside the wall (where sticky blocks go).
-                BlockPos wallPos = gridToWallPos(direction, x, y);
-                BlockPos placementPos = wallPos.offset(direction, 1);
-
-                Block blockToPlace = switch (placement) {
-                    case SLIME -> Blocks.SLIME_BLOCK;
-                    case HONEY -> Blocks.HONEY_BLOCK;
-                    default -> null;
-                };
-
-                if (blockToPlace != null) {
-                    world.setBlockState(placementPos, blockToPlace.getDefaultState(), NOTIFY_LISTENERS);
-                }
-            }
-        }
-
-        // Place mob heads for each island
-        for (SolverResult.Island island : result.getIslands()) {
-            placeMobHeadsForIsland(direction, island);
-        }
-    }
-
-    // Places mob heads in L-shape pattern: 3 zombie heads + 1 wither skeleton skull.
-    private void placeMobHeadsForIsland(Direction direction, SolverResult.Island island) {
-        Set<int[]> cells = island.getCells();
-        if (cells.size() < 4) return;  // Need at least 4 cells for L-shape
-
-        // Find an L-shape in the island: 3 cells in a row + 1 perpendicular
-        int[] lShape = findLShape(cells);
-        if (lShape == null) return;
-
-        // lShape contains: [stem1X, stem1Y, stem2X, stem2Y, stem3X, stem3Y, cornerX, cornerY]
-        // Place 3 zombie heads on the stem (stem1, stem2, stem3)
-        // Place 1 wither skeleton skull on the corner
-
-        // Calculate head positions (2 blocks outside the wall)
-        BlockPos stem1Pos = gridToWallPos(direction, lShape[0], lShape[1]).offset(direction, 2);
-        BlockPos stem2Pos = gridToWallPos(direction, lShape[2], lShape[3]).offset(direction, 2);
-        BlockPos stem3Pos = gridToWallPos(direction, lShape[4], lShape[5]).offset(direction, 2);
-        BlockPos cornerPos = gridToWallPos(direction, lShape[6], lShape[7]).offset(direction, 2);
-
-        // Place zombie heads (wall variant if horizontal, floor variant if on top face)
-        placeSkull(stem1Pos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
-        placeSkull(stem2Pos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
-        placeSkull(stem3Pos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
-
-        // Place wither skeleton skull
-        placeSkull(cornerPos, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, direction);
-    }
-
-    // Places a skull: wall variant for horizontal faces, floor variant for up/down.
-    private void placeSkull(BlockPos pos, Block floorVariant, Block wallVariant, Direction faceDirection) {
-        if (faceDirection == Direction.UP || faceDirection == Direction.DOWN) {
-            // Floor variant for up/down faces
-            world.setBlockState(pos, floorVariant.getDefaultState(), NOTIFY_LISTENERS);
-        } else {
-            // Wall variant for horizontal faces
-            world.setBlockState(pos, wallVariant.getDefaultState()
-                    .with(net.minecraft.state.property.Properties.HORIZONTAL_FACING, faceDirection.getOpposite()), NOTIFY_LISTENERS);
-        }
-    }
-
-    // Finds an L-shape in cells. Returns [stem1X, stem1Y, stem2X, stem2Y, stem3X, stem3Y, cornerX, cornerY].
-    private int[] findLShape(Set<int[]> cells) {
-        // Convert to a more searchable format
-        Set<Long> cellKeys = new HashSet<>();
-        for (int[] cell : cells) {
-            cellKeys.add(((long) cell[0] << 16) | (cell[1] & 0xFFFF));
-        }
-
-        // Direction pairs for searching
-        int[][] directions = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
-
-        for (int[] cell : cells) {
-            int x = cell[0];
-            int y = cell[1];
-
-            // Try each direction as the "stem" direction
-            for (int[] stemDir : directions) {
-                // Check if we have 3 cells in a row (including this one as middle)
-                int prevX = x - stemDir[0];
-                int prevY = y - stemDir[1];
-                int nextX = x + stemDir[0];
-                int nextY = y + stemDir[1];
-
-                long prevKey = ((long) prevX << 16) | (prevY & 0xFFFF);
-                long nextKey = ((long) nextX << 16) | (nextY & 0xFFFF);
-
-                if (cellKeys.contains(prevKey) && cellKeys.contains(nextKey)) {
-                    // Found a stem of 3 cells: prev -> current -> next
-                    // Now find a perpendicular cell at either end
-
-                    // Check perpendicular directions
-                    for (int[] perpDir : directions) {
-                        // Skip if same direction as stem
-                        if (perpDir[0] == stemDir[0] && perpDir[1] == stemDir[1]) continue;
-                        if (perpDir[0] == -stemDir[0] && perpDir[1] == -stemDir[1]) continue;
-
-                        // Check corner at prev end
-                        int cornerX = prevX + perpDir[0];
-                        int cornerY = prevY + perpDir[1];
-                        long cornerKey = ((long) cornerX << 16) | (cornerY & 0xFFFF);
-
-                        if (cellKeys.contains(cornerKey)) {
-                            // Found L-shape: corner is perpendicular to prev
-                            return new int[]{prevX, prevY, x, y, nextX, nextY, cornerX, cornerY};
-                        }
-
-                        // Check corner at next end
-                        cornerX = nextX + perpDir[0];
-                        cornerY = nextY + perpDir[1];
-                        cornerKey = ((long) cornerX << 16) | (cornerY & 0xFFFF);
-
-                        if (cellKeys.contains(cornerKey)) {
-                            // Found L-shape: corner is perpendicular to next
-                            return new int[]{nextX, nextY, x, y, prevX, prevY, cornerX, cornerY};
-                        }
-                    }
-                }
-            }
-        }
-
-        return null;
     }
 
     private void buildTriggerWiringHorizontal(List<BlockPos> observerPositions, Direction slicingDirection) {

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -21,6 +21,7 @@ import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.kosma.geodesy.solver.FaceGrid;
@@ -33,9 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -69,6 +68,8 @@ public class GeodesyCore {
 
     // The directions used in the last /geodesy project command.
     private Direction @Nullable [] lastProjectedDirections;
+    // Used to makes sure another solve doesn't start while one is already running.
+    private CompletableFuture<Void> solveFuture;
 
     public void geodesyGeodesy() {
         sendCommandFeedback("Welcome to Geodesy!");
@@ -156,7 +157,7 @@ public class GeodesyCore {
 
 
         // Run the projection.
-        for (Direction direction: directions) {
+        for (Direction direction : directions) {
             this.projectGeode(direction);
         }
 
@@ -236,35 +237,30 @@ public class GeodesyCore {
             return;
         }
 
-        // Submit all solve tasks in parallel
-        CompletableFuture.runAsync(() -> geodesySolve(config, faceGrids));
-    }
-
-    private void geodesySolve(SolverConfig config, List<FaceGrid> faceGrids) {
-        BlockingQueue<SolverResult> futures = new LinkedBlockingQueue<>();
-        for (FaceGrid faceGrid : faceGrids) {
-
-            // Create a new solver instance for each face (thread safety)
-            CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(() -> new IslandFaceSolver().solve(faceGrid, config));
-
-            future.<Void>handle((result, e) -> {
-                if (e != null) {
-                    LOGGER.error("Failed to solve face {}", faceGrid.direction(), e);
-                    sendCommandFeedback("  %s: Failed to solve - %s", faceGrid.direction(), e.getMessage());
-                }
-                // Always add a result whether it failed or not because the next loop expects a set number of results
-                futures.add(result);
-                return null;
-            });
+        if (solveFuture != null && !solveFuture.isDone()) {
+            sendCommandFeedback("Solve already in progress. Please wait for it to finish before starting another.");
+            return;
         }
 
-        // Wait for all solves to complete and apply results
-        // Results are applied sequentially to ensure thread-safe world modifications
-        for (int i = 0; i < faceGrids.size(); i++) {
-            try {
-                SolverResult result = futures.take();
+        // Submit all solve tasks in parallel
+        @SuppressWarnings("rawtypes")
+        CompletableFuture[] futures = faceGrids.stream()
+                .map(faceGrid -> solveFace(config, faceGrid))
+                .toArray(CompletableFuture[]::new);
 
-                world.getServer().execute(() -> {
+        solveFuture = CompletableFuture.allOf(futures)
+                .thenRun(() -> world.getServer().execute(() -> sendCommandFeedback("Solve complete. Run /geodesy assemble when ready.")));
+    }
+
+    private @NonNull CompletableFuture<Void> solveFace(SolverConfig config, FaceGrid faceGrid) {
+        // Create a new solver instance for each face (thread safety)
+        return CompletableFuture.supplyAsync(() -> new IslandFaceSolver().solve(faceGrid, config))
+                .exceptionally(e -> {
+                    LOGGER.error("Failed to solve face {}", faceGrid.direction(), e);
+                    sendCommandFeedback("  %s: Failed to solve - %s", faceGrid.direction(), e.getMessage());
+                    return SolverResult.empty(faceGrid);
+                })
+                .thenAccept(result -> world.getServer().execute(() -> {
                     // Apply the solution to the world (must be on main thread)
                     applySolverResult(result.direction(), result);
 
@@ -276,15 +272,9 @@ public class GeodesyCore {
                             result.totalHarvest(),
                             result.getBlockCount(),
                             result.solveTimeMs(),
-                            result.timedOut() ? " (timed out)" : "");
-                });
-            } catch (Exception e) {
-                LOGGER.error("Error while applying solver results", e);
-                sendCommandFeedback("Error while applying solver results: %s", e.getMessage());
-            }
-        }
-
-        world.getServer().execute(() -> sendCommandFeedback("Solve complete. Run /geodesy assemble when ready."));
+                            result.timedOut() ? " (timed out)" : ""
+                    );
+                }));
     }
 
     // Clears sticky blocks and mob heads for a face. Allows re-running /geodesy solve.
@@ -501,11 +491,11 @@ public class GeodesyCore {
         }
 
         // Plop the clock at the top
-        BlockPos clockPos = new BlockPos((geode.getMinX()+geode.getMaxX())/2+3, geode.getMaxY()+CLOCK_Y_OFFSET, (geode.getMinZ()+geode.getMaxZ())/2+1);
+        BlockPos clockPos = new BlockPos((geode.getMinX() + geode.getMaxX()) / 2 + 3, geode.getMaxY() + CLOCK_Y_OFFSET, (geode.getMinZ() + geode.getMaxZ()) / 2 + 1);
         BlockPos torchPos = buildClock(clockPos, Direction.WEST, Direction.NORTH);
 
         // Run along all the axes and move all slime/honey blocks inside the frame.
-        for (Direction direction: Direction.values()) {
+        for (Direction direction : Direction.values()) {
             geode.slice(direction.getAxis(), slice -> {
                 // Calculate positions of the source and target blocks for moving.
                 BlockPos targetPos = slice.getEndpoint(direction).offset(direction, WALL_OFFSET);
@@ -520,7 +510,7 @@ public class GeodesyCore {
         }
 
         // Check each slice for a marker block.
-        for (Direction slicingDirection: Direction.values()) {
+        for (Direction slicingDirection : Direction.values()) {
             List<BlockPos> triggerObserverPositions = new ArrayList<>();
             geode.slice(slicingDirection.getAxis(), slice -> {
                 // Check for blocker marker block.
@@ -706,7 +696,7 @@ public class GeodesyCore {
     }
 
     private void buildWalls(IterableBlockBox wallsBox) {
-        for (Direction slicingDirection: Direction.values()) {
+        for (Direction slicingDirection : Direction.values()) {
             // Top wall (lid) is transparent but we still run the processing
             // to remove all blocks that should be removed.
             BlockState wallBlock = (slicingDirection == Direction.UP) ?
@@ -804,8 +794,8 @@ public class GeodesyCore {
 
     private void highlightGeode() {
         // Highlight the geode area.
-        int commandBlockOffset = WALL_OFFSET+1;
-        BlockPos structureBlockPos = new BlockPos(geode.getMinX()-commandBlockOffset, geode.getMinY()-commandBlockOffset, geode.getMinZ()-commandBlockOffset);
+        int commandBlockOffset = WALL_OFFSET + 1;
+        BlockPos structureBlockPos = new BlockPos(geode.getMinX() - commandBlockOffset, geode.getMinY() - commandBlockOffset, geode.getMinZ() - commandBlockOffset);
         BlockState structureBlockState = Blocks.STRUCTURE_BLOCK.getDefaultState().with(StructureBlock.MODE, StructureBlockMode.SAVE);
         world.setBlockState(structureBlockPos, structureBlockState, NOTIFY_LISTENERS);
         StructureBlockBlockEntity structure = (StructureBlockBlockEntity) world.getBlockEntity(structureBlockPos);
@@ -850,6 +840,7 @@ public class GeodesyCore {
      * Project the geode to a plane in a direction
      * Slices with budding amethyst(s) are marked with crying obsidian.
      * Slices with amethyst cluster(s) that needs to be harvested are marked with pumpkin.
+     *
      * @param direction The direction to project the geode to.
      * @author Kosma Moczek, Kevinthegreat
      */
@@ -879,7 +870,8 @@ public class GeodesyCore {
 
     /**
      * Get the position on the wall (with wall offset) of the geode bounding box for a position in a direction.
-     * @param blockPos The block position.
+     *
+     * @param blockPos  The block position.
      * @param direction The direction.
      * @return The position on the wall (with wall offset).
      * @author Kevinthegreat
@@ -956,8 +948,8 @@ public class GeodesyCore {
 
     private BlockPos buildClock(BlockPos startPos, Direction directionMain, Direction directionSide) {
         // Platform
-        for (int i=0; i<6; i++)
-            for (int j=0; j<3; j++)
+        for (int i = 0; i < 6; i++)
+            for (int j = 0; j < 3; j++)
                 world.setBlockState(startPos.offset(directionMain, i).offset(directionSide, j), FULL_BLOCK.getDefaultState());
 
         // Four solid blocks

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -249,8 +249,8 @@ public class GeodesyCore {
 
             future.<Void>handle((result, e) -> {
                 if (e != null) {
-                    LOGGER.error("Failed to solve face {}", faceGrid.getDirection(), e);
-                    sendCommandFeedback("  %s: Failed to solve - %s", faceGrid.getDirection(), e.getMessage());
+                    LOGGER.error("Failed to solve face {}", faceGrid.direction(), e);
+                    sendCommandFeedback("  %s: Failed to solve - %s", faceGrid.direction(), e.getMessage());
                 }
                 // Always add a result whether it failed or not because the next loop expects a set number of results
                 futures.add(result);
@@ -266,17 +266,17 @@ public class GeodesyCore {
 
                 world.getServer().execute(() -> {
                     // Apply the solution to the world (must be on main thread)
-                    applySolverResult(result.getDirection(), result);
+                    applySolverResult(result.direction(), result);
 
                     // Report results
                     sendCommandFeedback("  %s: %.0f%% coverage (%d/%d), %d blocks, %dms%s",
-                            result.getDirection(),
+                            result.direction(),
                             result.getCoveragePercent(),
-                            result.getHarvestCovered(),
-                            result.getTotalHarvest(),
+                            result.harvestCovered(),
+                            result.totalHarvest(),
                             result.getBlockCount(),
-                            result.getSolveTimeMs(),
-                            result.isTimedOut() ? " (timed out)" : "");
+                            result.solveTimeMs(),
+                            result.timedOut() ? " (timed out)" : "");
                 });
             } catch (Exception e) {
                 LOGGER.error("Error while applying solver results", e);
@@ -433,8 +433,8 @@ public class GeodesyCore {
     private void applySolverResult(Direction direction, SolverResult result) {
         // Place sticky blocks for each cell
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
-        for (int x = 0; x < result.getWidth(); x++) {
-            for (int y = 0; y < result.getHeight(); y++) {
+        for (int x = 0; x < result.width(); x++) {
+            for (int y = 0; y < result.height(); y++) {
                 byte placement = result.getPlacement(x, y);
                 if (placement == 0) {
                     continue;
@@ -457,7 +457,7 @@ public class GeodesyCore {
         }
 
         // Place mob heads for each island
-        for (IslandFaceSolver.Island island : result.getIslands()) {
+        for (IslandFaceSolver.Island island : result.islands()) {
             placeMobHeadsForIsland(direction, island);
         }
     }

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -1046,7 +1046,7 @@ public class GeodesyCore {
     private WeakReference<ServerPlayerEntity> player;
 
     public void setPlayerEntity(ServerPlayerEntity player) {
-        if (this.player.get() != player) this.player = new WeakReference<>(player);
+        if (this.player == null || this.player.get() != player) this.player = new WeakReference<>(player);
     }
 
     private void sendCommandFeedback(Text message) {

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -102,6 +102,30 @@ public class GeodesyCore {
         }
     }
 
+    public void geodesyAnalyze() {
+        sendCommandFeedback("---");
+
+        // Return if geodesy area has not been run yet.
+        if (geode == null) {
+            sendCommandFeedback("No area to analyze. Select an area with /geodesy area first.");
+            return;
+        }
+
+        // Run all possible projections and show the efficiencies.
+        sendCommandFeedback("Projection efficiency:");
+        geodesyProject(new Direction[]{Direction.EAST});
+        geodesyProject(new Direction[]{Direction.SOUTH});
+        geodesyProject(new Direction[]{Direction.UP});
+        geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH});
+        geodesyProject(new Direction[]{Direction.EAST, Direction.UP});
+        geodesyProject(new Direction[]{Direction.SOUTH, Direction.UP});
+        geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH, Direction.UP});
+        // Clean up the results of the last projection.
+        geodesyProject(null);
+        // Advise the user.
+        sendCommandFeedback("Now run /geodesy project with your chosen projections.");
+    }
+
     void geodesyProject(Direction[] directions) {
         // Return if geodesy area has not been run yet.
         if (geode == null || buddingAmethystPositions == null || amethystClusterPositions == null) {
@@ -157,28 +181,13 @@ public class GeodesyCore {
         sendCommandFeedback(" %s: %d%% (%d/%d)", layoutName, (int) efficiency, clustersCollected, amethystClusterPositions.size());
     }
 
-    public void geodesyAnalyze() {
+    void geodesyProjectCommand(Direction[] directions) {
         sendCommandFeedback("---");
 
-        // Return if geodesy area has not been run yet.
-        if (geode == null) {
-            sendCommandFeedback("No area to analyze. Select an area with /geodesy area first.");
-            return;
-        }
+        geodesyProject(directions);
 
-        // Run all possible projections and show the efficiencies.
-        sendCommandFeedback("Projection efficiency:");
-        geodesyProject(new Direction[]{Direction.EAST});
-        geodesyProject(new Direction[]{Direction.SOUTH});
-        geodesyProject(new Direction[]{Direction.UP});
-        geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH});
-        geodesyProject(new Direction[]{Direction.EAST, Direction.UP});
-        geodesyProject(new Direction[]{Direction.SOUTH, Direction.UP});
-        geodesyProject(new Direction[]{Direction.EAST, Direction.SOUTH, Direction.UP});
-        // Clean up the results of the last projection.
-        geodesyProject(null);
-        // Advise the user.
-        sendCommandFeedback("Now run /geodesy project with your chosen projections.");
+        sendCommandFeedback("Now run /geodesy solve to find optimal slime/honey block placement for this layout.");
+        sendCommandFeedback("Alternatively, you can place blocks and skulls manually.");
     }
 
     // Solve for optimal slime/honey block placement. Must be run after /geodesy project.
@@ -353,9 +362,9 @@ public class GeodesyCore {
 
         // Iterate through the wall and populate the grid.
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
-        for (int w = 0; w < width; w++) {
-            for (int h = 0; h < height; h++) {
-                setMutableToWallPos(mutablePos, direction, w, h);
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                setMutableToWallPos(mutablePos, direction, x, y);
                 Block block = world.getBlockState(mutablePos).getBlock();
 
                 byte cellValue;
@@ -366,7 +375,7 @@ public class GeodesyCore {
                 } else {
                     cellValue = FaceGrid.CELL_AIR;
                 }
-                grid.setCell(w, h, cellValue);
+                grid.setCell(x, y, cellValue);
             }
         }
 

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -17,27 +17,22 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
 import net.minecraft.util.Pair;
-import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import pl.kosma.geodesy.solver.FaceGrid;
 import pl.kosma.geodesy.solver.IslandFaceSolver;
 import pl.kosma.geodesy.solver.SolverConfig;
 import pl.kosma.geodesy.solver.SolverResult;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -70,8 +65,7 @@ public class GeodesyCore {
     private List<Pair<BlockPos, Direction>> amethystClusterPositions;
 
     // The directions used in the last /geodesy project command.
-    @Nullable
-    private Direction[] lastProjectedDirections;
+    private Direction @Nullable [] lastProjectedDirections;
 
     public void geodesyGeodesy() {
         sendCommandFeedback("Welcome to Geodesy!");
@@ -231,7 +225,7 @@ public class GeodesyCore {
         }
 
         // Submit all solve tasks in parallel
-        Map<Direction, CompletableFuture<SolverResult>> futures = new LinkedHashMap<>();
+        BlockingQueue<Pair<Direction, SolverResult>> futures = new LinkedBlockingQueue<>();
         for (Map.Entry<Direction, FaceGrid> entry : faceGrids.entrySet()) {
             Direction direction = entry.getKey();
             FaceGrid faceGrid = entry.getValue();
@@ -239,15 +233,24 @@ public class GeodesyCore {
             // Create a new solver instance for each face (thread safety)
             CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(() -> new IslandFaceSolver().solve(faceGrid, config));
 
-            futures.put(direction, future);
+            future.<Void>handle((result, e) -> {
+                if (e != null) {
+                    LOGGER.error("Failed to solve face {}", direction, e);
+                    sendCommandFeedback("  %s: Failed to solve - %s", direction, e.getMessage());
+                }
+                // Always add a result whether it failed or not because the next loop expects a set number of results
+                futures.add(new Pair<>(direction, result));
+                return null;
+            });
         }
 
         // Wait for all solves to complete and apply results
         // Results are applied sequentially to ensure thread-safe world modifications
-        for (Map.Entry<Direction, CompletableFuture<SolverResult>> entry : futures.entrySet()) {
-            Direction direction = entry.getKey();
+        for (int i = 0; i < faceGrids.size(); i++) {
             try {
-                SolverResult result = entry.getValue().join();
+                Pair<Direction, SolverResult> entry = futures.take();
+                Direction direction = entry.getLeft();
+                SolverResult result = entry.getRight();
 
                 // Apply the solution to the world (must be on main thread)
                 applySolverResult(direction, result);
@@ -262,8 +265,8 @@ public class GeodesyCore {
                         result.getSolveTimeMs(),
                         result.isTimedOut() ? " (timed out)" : "");
             } catch (Exception e) {
-                LOGGER.error("Failed to solve face {}", direction, e);
-                sendCommandFeedback("  %s: Failed to solve - %s", direction, e.getMessage());
+                LOGGER.error("Error while applying solver results", e);
+                sendCommandFeedback("Error while applying solver results: %s", e.getMessage());
             }
         }
 

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -484,8 +484,7 @@ public class GeodesyCore {
             world.setBlockState(pos, floorVariant.getDefaultState(), NOTIFY_LISTENERS);
         } else {
             // Wall variant for horizontal faces
-            world.setBlockState(pos, wallVariant.getDefaultState()
-                    .with(net.minecraft.state.property.Properties.HORIZONTAL_FACING, faceDirection.getOpposite()), NOTIFY_LISTENERS);
+            world.setBlockState(pos, wallVariant.getDefaultState().with(Properties.HORIZONTAL_FACING, faceDirection), NOTIFY_LISTENERS);
         }
     }
 

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -421,8 +421,8 @@ public class GeodesyCore {
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
         for (int x = 0; x < result.getWidth(); x++) {
             for (int y = 0; y < result.getHeight(); y++) {
-                SolverResult.PlacementType placement = result.getPlacement(x, y);
-                if (placement == SolverResult.PlacementType.NONE) {
+                byte placement = result.getPlacement(x, y);
+                if (placement == 0) {
                     continue;
                 }
 
@@ -431,8 +431,8 @@ public class GeodesyCore {
                 mutablePos.move(direction, 1);
 
                 Block blockToPlace = switch (placement) {
-                    case SLIME -> Blocks.SLIME_BLOCK;
-                    case HONEY -> Blocks.HONEY_BLOCK;
+                    case IslandFaceSolver.SLIME -> Blocks.SLIME_BLOCK;
+                    case IslandFaceSolver.HONEY -> Blocks.HONEY_BLOCK;
                     default -> null;
                 };
 
@@ -443,51 +443,29 @@ public class GeodesyCore {
         }
 
         // Place mob heads for each island
-        for (SolverResult.Island island : result.getIslands()) {
+        for (IslandFaceSolver.Island island : result.getIslands()) {
             placeMobHeadsForIsland(direction, island);
         }
     }
 
     // Places mob heads in L-shape pattern: 3 zombie heads + 1 wither skeleton skull.
     // Uses the pre-computed L-shape data from the solver result.
-    private void placeMobHeadsForIsland(Direction direction, SolverResult.Island island) {
-        Set<int[]> lShapeCells = island.getLShapeCells();
-        if (lShapeCells == null || lShapeCells.size() != 4) return;
-
-        // The L-shape cells are [x, y] pairs. We need to identify the stem (3 in a row)
-        // and the corner (1 perpendicular). Find the stem by looking for 3 collinear cells.
-        int[][] cellArray = lShapeCells.toArray(new int[0][]);
-
-        // Find which cell is the corner: the one not collinear with the other three.
-        // A corner cell shares neither row nor column with all other cells in a line.
-        int cornerIdx = -1;
-        for (int i = 0; i < 4; i++) {
-            // Check if removing this cell leaves 3 collinear cells
-            int[] others = new int[3];
-            int idx = 0;
-            for (int j = 0; j < 4; j++) {
-                if (j != i) others[idx++] = j;
-            }
-            // 3 cells are collinear if they share the same x or same y
-            boolean sameX = cellArray[others[0]][0] == cellArray[others[1]][0] && cellArray[others[1]][0] == cellArray[others[2]][0];
-            boolean sameY = cellArray[others[0]][1] == cellArray[others[1]][1] && cellArray[others[1]][1] == cellArray[others[2]][1];
-            if (sameX || sameY) {
-                cornerIdx = i;
-                break;
-            }
+    private void placeMobHeadsForIsland(Direction direction, IslandFaceSolver.Island island) {
+        if (island.lShape() == null || island.lShape().stemCells() == null || island.lShape().stemCells().size() != 3) {
+            LOGGER.warn("Island with unexpected L-shape: {}. Island: {}", island.lShape(), island);
+            sendCommandFeedback("Island with unexpected L-shape: %s. Island: %s", island.lShape(), island);
+            return;
         }
-
-        if (cornerIdx == -1) return;
 
         // Place zombie heads on stem cells, wither skeleton skull on corner
-        for (int i = 0; i < 4; i++) {
-            BlockPos headPos = gridToWallPos(direction, cellArray[i][0], cellArray[i][1]).move(direction, 2);
-            if (i == cornerIdx) {
-                placeSkull(headPos, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, direction);
-            } else {
-                placeSkull(headPos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
-            }
+        for (int cell : island.lShape().stemCells()) {
+            BlockPos headPos = gridToWallPos(direction, IslandFaceSolver.keyRow(cell), IslandFaceSolver.keyCol(cell)).move(direction, 2);
+            placeSkull(headPos, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, direction);
         }
+
+        int stopperCell = island.lShape().stopperCell();
+        BlockPos stopperPos = gridToWallPos(direction, IslandFaceSolver.keyRow(stopperCell), IslandFaceSolver.keyCol(stopperCell)).move(direction, 2);
+        placeSkull(stopperPos, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, direction);
     }
 
     // Places a skull: wall variant for horizontal faces, floor variant for up/down.

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -29,7 +29,10 @@ import pl.kosma.geodesy.solver.SolverConfig;
 import pl.kosma.geodesy.solver.SolverResult;
 
 import java.lang.ref.WeakReference;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -218,11 +221,11 @@ public class GeodesyCore {
         sendCommandFeedback("Solving %d face(s) in parallel: %s...", lastProjectedDirections.length, directionNames);
 
         // Extract all face grids first (must be done on main thread for world access)
-        Map<Direction, FaceGrid> faceGrids = new LinkedHashMap<>();
+        List<FaceGrid> faceGrids = new ArrayList<>(6);
         for (Direction direction : lastProjectedDirections) {
             FaceGrid faceGrid = extractFaceGrid(direction);
             if (faceGrid != null) {
-                faceGrids.put(direction, faceGrid);
+                faceGrids.add(faceGrid);
             } else {
                 sendCommandFeedback("  %s: Failed to extract face grid.", direction);
             }
@@ -234,21 +237,23 @@ public class GeodesyCore {
         }
 
         // Submit all solve tasks in parallel
-        BlockingQueue<Pair<Direction, SolverResult>> futures = new LinkedBlockingQueue<>();
-        for (Map.Entry<Direction, FaceGrid> entry : faceGrids.entrySet()) {
-            Direction direction = entry.getKey();
-            FaceGrid faceGrid = entry.getValue();
+        CompletableFuture.runAsync(() -> geodesySolve(config, faceGrids));
+    }
+
+    private void geodesySolve(SolverConfig config, List<FaceGrid> faceGrids) {
+        BlockingQueue<SolverResult> futures = new LinkedBlockingQueue<>();
+        for (FaceGrid faceGrid : faceGrids) {
 
             // Create a new solver instance for each face (thread safety)
             CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(() -> new IslandFaceSolver().solve(faceGrid, config));
 
             future.<Void>handle((result, e) -> {
                 if (e != null) {
-                    LOGGER.error("Failed to solve face {}", direction, e);
-                    sendCommandFeedback("  %s: Failed to solve - %s", direction, e.getMessage());
+                    LOGGER.error("Failed to solve face {}", faceGrid.getDirection(), e);
+                    sendCommandFeedback("  %s: Failed to solve - %s", faceGrid.getDirection(), e.getMessage());
                 }
                 // Always add a result whether it failed or not because the next loop expects a set number of results
-                futures.add(new Pair<>(direction, result));
+                futures.add(result);
                 return null;
             });
         }
@@ -257,29 +262,29 @@ public class GeodesyCore {
         // Results are applied sequentially to ensure thread-safe world modifications
         for (int i = 0; i < faceGrids.size(); i++) {
             try {
-                Pair<Direction, SolverResult> entry = futures.take();
-                Direction direction = entry.getLeft();
-                SolverResult result = entry.getRight();
+                SolverResult result = futures.take();
 
-                // Apply the solution to the world (must be on main thread)
-                applySolverResult(direction, result);
+                world.getServer().execute(() -> {
+                    // Apply the solution to the world (must be on main thread)
+                    applySolverResult(result.getDirection(), result);
 
-                // Report results
-                sendCommandFeedback("  %s: %.0f%% coverage (%d/%d), %d blocks, %dms%s",
-                        direction,
-                        result.getCoveragePercent(),
-                        result.getHarvestCovered(),
-                        result.getTotalHarvest(),
-                        result.getBlockCount(),
-                        result.getSolveTimeMs(),
-                        result.isTimedOut() ? " (timed out)" : "");
+                    // Report results
+                    sendCommandFeedback("  %s: %.0f%% coverage (%d/%d), %d blocks, %dms%s",
+                            result.getDirection(),
+                            result.getCoveragePercent(),
+                            result.getHarvestCovered(),
+                            result.getTotalHarvest(),
+                            result.getBlockCount(),
+                            result.getSolveTimeMs(),
+                            result.isTimedOut() ? " (timed out)" : "");
+                });
             } catch (Exception e) {
                 LOGGER.error("Error while applying solver results", e);
                 sendCommandFeedback("Error while applying solver results: %s", e.getMessage());
             }
         }
 
-        sendCommandFeedback("Solve complete. Run /geodesy assemble when ready.");
+        world.getServer().execute(() -> sendCommandFeedback("Solve complete. Run /geodesy assemble when ready."));
     }
 
     // Clears sticky blocks and mob heads for a face. Allows re-running /geodesy solve.
@@ -1041,7 +1046,7 @@ public class GeodesyCore {
     private WeakReference<ServerPlayerEntity> player;
 
     public void setPlayerEntity(ServerPlayerEntity player) {
-        this.player = new WeakReference<>(player);
+        if (this.player.get() != player) this.player = new WeakReference<>(player);
     }
 
     private void sendCommandFeedback(Text message) {

--- a/src/main/java/pl/kosma/geodesy/GeodesyCore.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyCore.java
@@ -230,15 +230,14 @@ public class GeodesyCore {
             return;
         }
 
-        // Submit all solve tasks in parallel using Minecraft's shared worker pool
+        // Submit all solve tasks in parallel
         Map<Direction, CompletableFuture<SolverResult>> futures = new LinkedHashMap<>();
         for (Map.Entry<Direction, FaceGrid> entry : faceGrids.entrySet()) {
             Direction direction = entry.getKey();
             FaceGrid faceGrid = entry.getValue();
 
             // Create a new solver instance for each face (thread safety)
-            CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(
-                    () -> new IslandFaceSolver().solve(faceGrid, config), Util.getMainWorkerExecutor());
+            CompletableFuture<SolverResult> future = CompletableFuture.supplyAsync(() -> new IslandFaceSolver().solve(faceGrid, config));
 
             futures.put(direction, future);
         }
@@ -299,17 +298,17 @@ public class GeodesyCore {
         BlockPos.Mutable mutablePos = new BlockPos.Mutable();
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                BlockPos wallPos = gridToWallPos(direction, x, y);
+                setMutableToWallPos(mutablePos, direction, x, y);
 
                 // Clear sticky block layer (wall + 1)
-                mutablePos.set(wallPos).move(direction, 1);
+                mutablePos.move(direction, 1);
                 Block stickyBlock = world.getBlockState(mutablePos).getBlock();
                 if (STICKY_BLOCKS.contains(stickyBlock)) {
                     world.setBlockState(mutablePos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
                 }
 
                 // Clear mob head layer (wall + 2)
-                mutablePos.set(wallPos).move(direction, 2);
+                mutablePos.move(direction, 1);
                 Block headBlock = world.getBlockState(mutablePos).getBlock();
                 if (MARKERS_BLOCKER.contains(headBlock) || MARKERS_MACHINE.contains(headBlock)) {
                     world.setBlockState(mutablePos, Blocks.AIR.getDefaultState(), NOTIFY_LISTENERS);
@@ -372,29 +371,29 @@ public class GeodesyCore {
     }
 
     // Converts grid coordinates to world wall position.
-    private BlockPos gridToWallPos(Direction direction, int gridX, int gridY) {
+    private BlockPos.Mutable gridToWallPos(Direction direction, int gridX, int gridY) {
         return switch (direction) {
-            case EAST -> new BlockPos(
+            case EAST -> new BlockPos.Mutable(
                     geode.getMaxX() + WALL_OFFSET,
                     geode.getMinY() + gridY,
                     geode.getMinZ() + gridX);
-            case WEST -> new BlockPos(
+            case WEST -> new BlockPos.Mutable(
                     geode.getMinX() - WALL_OFFSET,
                     geode.getMinY() + gridY,
                     geode.getMinZ() + gridX);
-            case UP -> new BlockPos(
+            case UP -> new BlockPos.Mutable(
                     geode.getMinX() + gridX,
                     geode.getMaxY() + WALL_OFFSET,
                     geode.getMinZ() + gridY);
-            case DOWN -> new BlockPos(
+            case DOWN -> new BlockPos.Mutable(
                     geode.getMinX() + gridX,
                     geode.getMinY() - WALL_OFFSET,
                     geode.getMinZ() + gridY);
-            case SOUTH -> new BlockPos(
+            case SOUTH -> new BlockPos.Mutable(
                     geode.getMinX() + gridX,
                     geode.getMinY() + gridY,
                     geode.getMaxZ() + WALL_OFFSET);
-            case NORTH -> new BlockPos(
+            case NORTH -> new BlockPos.Mutable(
                     geode.getMinX() + gridX,
                     geode.getMinY() + gridY,
                     geode.getMinZ() - WALL_OFFSET);
@@ -416,6 +415,7 @@ public class GeodesyCore {
     // Applies solver result: places slime/honey blocks and mob heads.
     private void applySolverResult(Direction direction, SolverResult result) {
         // Place sticky blocks for each cell
+        BlockPos.Mutable mutablePos = new BlockPos.Mutable();
         for (int x = 0; x < result.getWidth(); x++) {
             for (int y = 0; y < result.getHeight(); y++) {
                 SolverResult.PlacementType placement = result.getPlacement(x, y);
@@ -424,8 +424,8 @@ public class GeodesyCore {
                 }
 
                 // Calculate the position one block outside the wall (where sticky blocks go).
-                BlockPos wallPos = gridToWallPos(direction, x, y);
-                BlockPos placementPos = wallPos.offset(direction, 1);
+                setMutableToWallPos(mutablePos, direction, x, y);
+                mutablePos.move(direction, 1);
 
                 Block blockToPlace = switch (placement) {
                     case SLIME -> Blocks.SLIME_BLOCK;
@@ -434,7 +434,7 @@ public class GeodesyCore {
                 };
 
                 if (blockToPlace != null) {
-                    world.setBlockState(placementPos, blockToPlace.getDefaultState(), NOTIFY_LISTENERS);
+                    world.setBlockState(mutablePos, blockToPlace.getDefaultState(), NOTIFY_LISTENERS);
                 }
             }
         }
@@ -478,7 +478,7 @@ public class GeodesyCore {
 
         // Place zombie heads on stem cells, wither skeleton skull on corner
         for (int i = 0; i < 4; i++) {
-            BlockPos headPos = gridToWallPos(direction, cellArray[i][0], cellArray[i][1]).offset(direction, 2);
+            BlockPos headPos = gridToWallPos(direction, cellArray[i][0], cellArray[i][1]).move(direction, 2);
             if (i == cornerIdx) {
                 placeSkull(headPos, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, direction);
             } else {

--- a/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
@@ -220,11 +220,11 @@ public class GeodesyFabricMod implements ModInitializer {
     private int geodesyProjectCommand(CommandContext<ServerCommandSource> context, int argumentIndex) {
         try {
             GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-            Set<Direction> directions = new LinkedHashSet<>(argumentIndex);
+            Direction[] directions = new Direction[argumentIndex];
             for (int i = 1; i <= argumentIndex; i++) {
-                directions.add(DirectionArgumentType.getDirection(context, "direction" + i));
+                directions[i - 1] = DirectionArgumentType.getDirection(context, "direction" + i);
             }
-            context.getSource().getServer().execute(() -> core.geodesyProject(directions.isEmpty() ? null : directions.toArray(new Direction[argumentIndex])));
+            context.getSource().getServer().execute(() -> core.geodesyProjectCommand(directions));
             return SINGLE_SUCCESS;
         } catch (Exception e) {
             LOGGER.error("project", e);

--- a/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
@@ -145,28 +145,17 @@ public class GeodesyFabricMod implements ModInitializer {
                                 .executes(context -> geodesyProjectCommand(context,2)))
                             .executes(context -> geodesyProjectCommand(context,1)))
                         .executes(context -> geodesyProjectCommand(context,0)))
-                    .then(literal("assemble").executes(context -> {
-                        try {
-                            GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-                            context.getSource().getServer().execute(core::geodesyAssemble);
-                            return SINGLE_SUCCESS;
-                        }
-                        catch (Exception e) {
-                            LOGGER.error("assemble", e);
-                            throw (e);
-                        }
-                    }))
                     .then(literal("solve")
-                        .then(argument("timeout", IntegerArgumentType.integer(1, 300))
-                            .then(argument("cost", DoubleArgumentType.doubleArg(1.0, 12.0))
+                        .then(argument("cost", DoubleArgumentType.doubleArg(1.0, 12.0))
+                            .then(argument("timeout", IntegerArgumentType.integer(1, 300))
                                 .executes(context -> {
                                     try {
                                         GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-                                        int timeout = IntegerArgumentType.getInteger(context, "timeout");
                                         double cost = DoubleArgumentType.getDouble(context, "cost");
+                                        int timeout = IntegerArgumentType.getInteger(context, "timeout");
                                         SolverConfig config = SolverConfig.builder()
-                                                .timeoutMs(timeout * 1000L)
                                                 .costThreshold(cost)
+                                                .timeoutMs(timeout * 1000L)
                                                 .build();
                                         context.getSource().getServer().execute(() -> core.geodesySolve(config));
                                         return SINGLE_SUCCESS;
@@ -179,9 +168,9 @@ public class GeodesyFabricMod implements ModInitializer {
                             .executes(context -> {
                                 try {
                                     GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-                                    int timeout = IntegerArgumentType.getInteger(context, "timeout");
+                                    double cost = DoubleArgumentType.getDouble(context, "cost");
                                     SolverConfig config = SolverConfig.builder()
-                                            .timeoutMs(timeout * 1000L)
+                                            .costThreshold(cost)
                                             .build();
                                     context.getSource().getServer().execute(() -> core.geodesySolve(config));
                                     return SINGLE_SUCCESS;
@@ -202,6 +191,17 @@ public class GeodesyFabricMod implements ModInitializer {
                                 throw (e);
                             }
                         }))
+                    .then(literal("assemble").executes(context -> {
+                        try {
+                            GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
+                            context.getSource().getServer().execute(core::geodesyAssemble);
+                            return SINGLE_SUCCESS;
+                        }
+                        catch (Exception e) {
+                            LOGGER.error("assemble", e);
+                            throw (e);
+                        }
+                    }))
                     .executes(context -> {
                         try {
                             GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());

--- a/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
@@ -1,11 +1,11 @@
 package pl.kosma.geodesy;
 
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
-import com.mojang.brigadier.arguments.DoubleArgumentType;
-import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.command.argument.serialize.ConstantArgumentSerializer;
 import net.minecraft.server.command.CommandManager;
@@ -16,9 +16,9 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import org.jetbrains.annotations.Nullable;
-import pl.kosma.geodesy.solver.SolverConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import pl.kosma.geodesy.solver.SolverConfig;
 
 import java.util.*;
 

--- a/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyFabricMod.java
@@ -146,16 +146,16 @@ public class GeodesyFabricMod implements ModInitializer {
                             .executes(context -> geodesyProjectCommand(context,1)))
                         .executes(context -> geodesyProjectCommand(context,0)))
                     .then(literal("solve")
-                        .then(argument("cost", DoubleArgumentType.doubleArg(1.0, 12.0))
-                            .then(argument("timeout", IntegerArgumentType.integer(1, 300))
+                        .then(argument("timeout", IntegerArgumentType.integer(1, 300))
+                            .then(argument("cost", DoubleArgumentType.doubleArg(1.0, 12.0))
                                 .executes(context -> {
                                     try {
                                         GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-                                        double cost = DoubleArgumentType.getDouble(context, "cost");
                                         int timeout = IntegerArgumentType.getInteger(context, "timeout");
+                                        double cost = DoubleArgumentType.getDouble(context, "cost");
                                         SolverConfig config = SolverConfig.builder()
-                                                .costThreshold(cost)
                                                 .timeoutMs(timeout * 1000L)
+                                                .costThreshold(cost)
                                                 .build();
                                         context.getSource().getServer().execute(() -> core.geodesySolve(config));
                                         return SINGLE_SUCCESS;
@@ -168,9 +168,9 @@ public class GeodesyFabricMod implements ModInitializer {
                             .executes(context -> {
                                 try {
                                     GeodesyCore core = getPerPlayerCore(context.getSource().getPlayer());
-                                    double cost = DoubleArgumentType.getDouble(context, "cost");
+                                    int timeout = IntegerArgumentType.getInteger(context, "timeout");
                                     SolverConfig config = SolverConfig.builder()
-                                            .costThreshold(cost)
+                                            .timeoutMs(timeout * 1000L)
                                             .build();
                                     context.getSource().getServer().execute(() -> core.geodesySolve(config));
                                     return SINGLE_SUCCESS;

--- a/src/main/java/pl/kosma/geodesy/GeodesyTest.java
+++ b/src/main/java/pl/kosma/geodesy/GeodesyTest.java
@@ -15,32 +15,44 @@ public class GeodesyTest {
         CommandManager commandManager = server.getCommandManager();
         ServerCommandSource commandSource = server.getCommandSource();
 
+        commandManager.parseAndExecute(commandSource, "/gamerule random_tick_speed 0");
+
         BlockPos absolutePos = context.getAbsolutePos(new BlockPos(18, 18, 18));
         commandManager.parseAndExecute(commandSource, "/geodesy area " + absolutePos.getX() + " " + absolutePos.getY() + " " + absolutePos.getZ() + " " + absolutePos.getX() + " " + absolutePos.getY() + " " + absolutePos.getZ());
         commandManager.parseAndExecute(commandSource, "/geodesy analyze");
         commandManager.parseAndExecute(commandSource, "/geodesy project north east down");
 
-        new IterableBlockBox(17, 17, 14, 19, 19, 14).forEachEdgePosition(pos -> context.setBlockState(pos, Blocks.SLIME_BLOCK));
-        context.setBlockState(19, 17, 13, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(19, 18, 13, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(19, 19, 13, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(18, 17, 13, Blocks.WITHER_SKELETON_WALL_SKULL);
+        commandManager.parseAndExecute(commandSource, "/geodesy solve");
+        context.waitAndRun(100, () -> {
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 17, 17, 13);
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 17, 18, 13);
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 17, 19, 13);
+            context.expectBlock(Blocks.WITHER_SKELETON_WALL_SKULL, 18, 17, 13);
 
-        new IterableBlockBox(22, 17, 17, 22, 19, 19).forEachEdgePosition(pos -> context.setBlockState(pos, Blocks.SLIME_BLOCK));
-        context.setBlockState(23, 17, 19, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(23, 18, 19, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(23, 19, 19, Blocks.ZOMBIE_WALL_HEAD);
-        context.setBlockState(23, 17, 18, Blocks.WITHER_SKELETON_WALL_SKULL);
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 23, 17, 17);
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 23, 17, 18);
+            context.expectBlock(Blocks.ZOMBIE_WALL_HEAD, 23, 17, 19);
+            context.expectBlock(Blocks.WITHER_SKELETON_WALL_SKULL, 23, 18, 17);
 
-        commandManager.parseAndExecute(commandSource, "/geodesy assemble");
-        context.putAndRemoveRedstoneBlock(new BlockPos(19, 17, 2), 1);
-        context.waitAndRun(150, () -> context.putAndRemoveRedstoneBlock(new BlockPos(34, 17, 19), 1));
-        context.waitAndRun(300, () -> {
-            new IterableBlockBox(17, 17, 15, 19, 19, 15).forEachEdgePosition(pos -> context.expectBlock(Blocks.SLIME_BLOCK, pos));
-            new IterableBlockBox(21, 17, 17, 21, 19, 19).forEachEdgePosition(pos -> context.expectBlock(Blocks.SLIME_BLOCK, pos));
-            context.expectBlock(Blocks.REDSTONE_LAMP, 19, 17, 12);
-            context.expectBlock(Blocks.REDSTONE_LAMP, 24, 17, 19);
+            commandManager.parseAndExecute(commandSource, "/geodesy assemble");
+            context.putAndRemoveRedstoneBlock(new BlockPos(17, 17, 2), 1);
+        });
+
+        context.waitAndRun(250, () -> context.putAndRemoveRedstoneBlock(new BlockPos(34, 16, 18), 1));
+        context.waitAndRun(400, () -> {
+            context.expectBlock(Blocks.SLIME_BLOCK, 18, 17, 15);
+            context.expectBlock(Blocks.SLIME_BLOCK, 21, 18, 17);
+            context.expectBlock(Blocks.REDSTONE_LAMP, 17, 17, 12);
+            context.expectBlock(Blocks.REDSTONE_LAMP, 24, 17, 17);
+
             context.expectBlock(Blocks.BUDDING_AMETHYST, 18, 18, 18);
+            context.expectBlock(Blocks.AIR, 17, 18, 18);
+            context.expectBlock(Blocks.AIR, 19, 18, 18);
+            context.expectBlock(Blocks.AIR, 18, 17, 18);
+            context.expectBlock(Blocks.AIR, 18, 19, 18);
+            context.expectBlock(Blocks.AIR, 18, 18, 17);
+            context.expectBlock(Blocks.AIR, 18, 18, 19);
+
             context.complete();
         });
     }

--- a/src/main/java/pl/kosma/geodesy/UnholyBookOfGeodesy.java
+++ b/src/main/java/pl/kosma/geodesy/UnholyBookOfGeodesy.java
@@ -21,7 +21,7 @@ public class UnholyBookOfGeodesy {
                    The Unholy Book
                      of Geodesy
                              *
-                  
+                
                       by Kosmolot
                 
                 
@@ -29,7 +29,7 @@ public class UnholyBookOfGeodesy {
                 /geodesy area
                 /geodesy analyze
                 /geodesy project
-                ...place blocks...
+                /geodesy solve
                 /geodesy assemble
                 """);
         pages.add(
@@ -73,7 +73,16 @@ public class UnholyBookOfGeodesy {
                 """);
         pages.add(
                 """
-                Step 5:
+                Steps 5-6: (Automatic Alternative)
+                /geodesy solve
+                
+                The mod will solve for a layout of flying machines. It's not perfect.
+                
+                Humans still better than computers, for now.
+                """);
+        pages.add(
+                """
+                Step 5: (Manual Alternative)
                 
                 Place sticky block structures on the sides of the farm. All moss blocks and no crying obsidian blocks should be covered.
                 
@@ -81,9 +90,9 @@ public class UnholyBookOfGeodesy {
                 """);
         pages.add(
                 """
-                Step 6:
+                Step 6: (Manual Alternative)
                 
-                Place mob heads as markers indicating where the flying machines should go. See the Curseforge mod page for details.
+                Place mob heads as markers indicating where the flying machines should go. See the Modrinth mod page for details.
                 
                 Just don't summon a wither!
                 """);
@@ -119,7 +128,7 @@ public class UnholyBookOfGeodesy {
                 
                 Feeling lost?
                 
-                Check out the mod page on Curseforge for screenshots and more detailed instructions.
+                Check out the mod page on Modrinth for screenshots and more detailed instructions.
                 """);
         grimoire.set(DataComponentTypes.WRITTEN_BOOK_CONTENT, new WrittenBookContentComponent(RawFilteredPair.of("The Unholy Book of Geodesy"), "Kosmolot", 0, pages.stream().map(Text::of).map(RawFilteredPair::of).toList(), true));
         return grimoire;

--- a/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
@@ -1,0 +1,102 @@
+package pl.kosma.geodesy.solver;
+
+import net.minecraft.util.math.Direction;
+
+/**
+ * Represents a 2D grid of a single face of the geode projection.
+ * This is the input to the solver algorithm.
+ *
+ * Cell values: 0 = air, -1 = blocked (crying obsidian), 1 = harvest (pumpkin)
+ */
+public class FaceGrid {
+
+    public static final int CELL_AIR = 0;
+    public static final int CELL_BLOCKED = -1;
+    public static final int CELL_HARVEST = 1;
+
+    private final int width;
+    private final int height;
+    private final int[][] cells;
+    private final Direction direction;
+
+    public FaceGrid(int width, int height, Direction direction) {
+        this.width = width;
+        this.height = height;
+        this.direction = direction;
+        this.cells = new int[width][height];
+    }
+
+    public FaceGrid(int[][] cells, Direction direction) {
+        this.width = cells.length;
+        this.height = cells.length > 0 ? cells[0].length : 0;
+        this.direction = direction;
+        this.cells = new int[width][height];
+        for (int x = 0; x < width; x++) {
+            System.arraycopy(cells[x], 0, this.cells[x], 0, height);
+        }
+    }
+
+    public int getCell(int x, int y) {
+        return cells[x][y];
+    }
+
+    public void setCell(int x, int y, int value) {
+        cells[x][y] = value;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public int countCells(int value) {
+        int count = 0;
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (cells[x][y] == value) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public int getHarvestCount() {
+        return countCells(CELL_HARVEST);
+    }
+
+    public int getBlockedCount() {
+        return countCells(CELL_BLOCKED);
+    }
+
+    public FaceGrid copy() {
+        return new FaceGrid(cells, direction);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("FaceGrid[").append(width).append("x").append(height)
+          .append(", direction=").append(direction).append("]\n");
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                char c = switch (cells[x][y]) {
+                    case CELL_AIR -> '.';
+                    case CELL_BLOCKED -> '#';
+                    case CELL_HARVEST -> 'P';
+                    default -> '?';
+                };
+                sb.append(c);
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
@@ -10,29 +10,17 @@ import net.minecraft.util.math.Direction;
  *
  * <p>Internal storage is row-major: cells[row][col] (i.e. cells[x][y]).
  */
-public class FaceGrid {
-
+public record FaceGrid(int width, int height, byte[][] cells, Direction direction) {
     public static final byte CELL_AIR = 0;
     public static final byte CELL_BLOCKED = -1;
     public static final byte CELL_HARVEST = 1;
 
-    private final int width;
-    private final int height;
-    private final byte[][] cells;
-    private final Direction direction;
-
     public FaceGrid(int width, int height, Direction direction) {
-        this.width = width;
-        this.height = height;
-        this.direction = direction;
-        this.cells = new byte[width][height];
+        this(width, height, new byte[width][height], direction);
     }
 
     public FaceGrid(byte[][] cells, int width, int height, Direction direction) {
-        this.width = width;
-        this.height = height;
-        this.direction = direction;
-        this.cells = new byte[width][height];
+        this(width, height, new byte[width][height], direction);
         for (int x = 0; x < width; x++) {
             System.arraycopy(cells[x], 0, this.cells[x], 0, height);
         }
@@ -44,18 +32,6 @@ public class FaceGrid {
 
     public void setCell(int x, int y, byte value) {
         cells[x][y] = value;
-    }
-
-    public int getWidth() {
-        return width;
-    }
-
-    public int getHeight() {
-        return height;
-    }
-
-    public Direction getDirection() {
-        return direction;
     }
 
     public int countCells(byte value) {

--- a/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
@@ -8,7 +8,7 @@ import net.minecraft.util.math.Direction;
  *
  * <p>Cell values: 0 = air, -1 = blocked (crying obsidian), 1 = harvest (pumpkin)
  *
- * <p>Internal storage is row-major: cells[row][col] (i.e. cells[y][x]).
+ * <p>Internal storage is row-major: cells[row][col] (i.e. cells[x][y]).
  */
 public class FaceGrid {
 
@@ -18,32 +18,32 @@ public class FaceGrid {
 
     private final int width;
     private final int height;
-    private final byte[][] cells;  // row-major: cells[y][x]
+    private final byte[][] cells;
     private final Direction direction;
 
     public FaceGrid(int width, int height, Direction direction) {
         this.width = width;
         this.height = height;
         this.direction = direction;
-        this.cells = new byte[height][width];
+        this.cells = new byte[width][height];
     }
 
     public FaceGrid(byte[][] cells, int width, int height, Direction direction) {
         this.width = width;
         this.height = height;
         this.direction = direction;
-        this.cells = new byte[height][width];
-        for (int y = 0; y < height; y++) {
-            System.arraycopy(cells[y], 0, this.cells[y], 0, width);
+        this.cells = new byte[width][height];
+        for (int x = 0; x < width; x++) {
+            System.arraycopy(cells[x], 0, this.cells[x], 0, height);
         }
     }
 
     public byte getCell(int x, int y) {
-        return cells[y][x];
+        return cells[x][y];
     }
 
     public void setCell(int x, int y, byte value) {
-        cells[y][x] = value;
+        cells[x][y] = value;
     }
 
     public int getWidth() {
@@ -60,9 +60,9 @@ public class FaceGrid {
 
     public int countCells(byte value) {
         int count = 0;
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                if (cells[y][x] == value) {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (cells[x][y] == value) {
                     count++;
                 }
             }
@@ -83,9 +83,9 @@ public class FaceGrid {
     }
 
     public byte[][] copyCells() {
-        byte[][] copy = new byte[height][width];
-        for (int y = 0; y < height; y++) {
-            System.arraycopy(cells[y], 0, copy[y], 0, width);
+        byte[][] copy = new byte[width][height];
+        for (int x = 0; x < width; x++) {
+            System.arraycopy(cells[x], 0, copy[x], 0, height);
         }
         return copy;
     }
@@ -95,9 +95,9 @@ public class FaceGrid {
         StringBuilder sb = new StringBuilder();
         sb.append("FaceGrid[").append(width).append("x").append(height)
           .append(", direction=").append(direction).append("]\n");
-        for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
-                char c = switch (cells[y][x]) {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                char c = switch (cells[x][y]) {
                     case CELL_AIR -> '.';
                     case CELL_BLOCKED -> '#';
                     case CELL_HARVEST -> 'P';

--- a/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
@@ -7,41 +7,43 @@ import net.minecraft.util.math.Direction;
  * This is the input to the solver algorithm.
  *
  * Cell values: 0 = air, -1 = blocked (crying obsidian), 1 = harvest (pumpkin)
+ *
+ * Internal storage is row-major: cells[row][col] (i.e. cells[y][x]).
  */
 public class FaceGrid {
 
-    public static final int CELL_AIR = 0;
-    public static final int CELL_BLOCKED = -1;
-    public static final int CELL_HARVEST = 1;
+    public static final byte CELL_AIR = 0;
+    public static final byte CELL_BLOCKED = -1;
+    public static final byte CELL_HARVEST = 1;
 
     private final int width;
     private final int height;
-    private final int[][] cells;
+    private final byte[][] cells;  // row-major: cells[y][x]
     private final Direction direction;
 
     public FaceGrid(int width, int height, Direction direction) {
         this.width = width;
         this.height = height;
         this.direction = direction;
-        this.cells = new int[width][height];
+        this.cells = new byte[height][width];
     }
 
-    public FaceGrid(int[][] cells, Direction direction) {
-        this.width = cells.length;
-        this.height = cells.length > 0 ? cells[0].length : 0;
+    public FaceGrid(byte[][] cells, int width, int height, Direction direction) {
+        this.width = width;
+        this.height = height;
         this.direction = direction;
-        this.cells = new int[width][height];
-        for (int x = 0; x < width; x++) {
-            System.arraycopy(cells[x], 0, this.cells[x], 0, height);
+        this.cells = new byte[height][width];
+        for (int y = 0; y < height; y++) {
+            System.arraycopy(cells[y], 0, this.cells[y], 0, width);
         }
     }
 
-    public int getCell(int x, int y) {
-        return cells[x][y];
+    public byte getCell(int x, int y) {
+        return cells[y][x];
     }
 
-    public void setCell(int x, int y, int value) {
-        cells[x][y] = value;
+    public void setCell(int x, int y, byte value) {
+        cells[y][x] = value;
     }
 
     public int getWidth() {
@@ -56,11 +58,11 @@ public class FaceGrid {
         return direction;
     }
 
-    public int countCells(int value) {
+    public int countCells(byte value) {
         int count = 0;
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                if (cells[x][y] == value) {
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                if (cells[y][x] == value) {
                     count++;
                 }
             }
@@ -77,7 +79,7 @@ public class FaceGrid {
     }
 
     public FaceGrid copy() {
-        return new FaceGrid(cells, direction);
+        return new FaceGrid(cells, width, height, direction);
     }
 
     @Override
@@ -87,7 +89,7 @@ public class FaceGrid {
           .append(", direction=").append(direction).append("]\n");
         for (int y = 0; y < height; y++) {
             for (int x = 0; x < width; x++) {
-                char c = switch (cells[x][y]) {
+                char c = switch (cells[y][x]) {
                     case CELL_AIR -> '.';
                     case CELL_BLOCKED -> '#';
                     case CELL_HARVEST -> 'P';

--- a/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceGrid.java
@@ -6,9 +6,9 @@ import net.minecraft.util.math.Direction;
  * Represents a 2D grid of a single face of the geode projection.
  * This is the input to the solver algorithm.
  *
- * Cell values: 0 = air, -1 = blocked (crying obsidian), 1 = harvest (pumpkin)
+ * <p>Cell values: 0 = air, -1 = blocked (crying obsidian), 1 = harvest (pumpkin)
  *
- * Internal storage is row-major: cells[row][col] (i.e. cells[y][x]).
+ * <p>Internal storage is row-major: cells[row][col] (i.e. cells[y][x]).
  */
 public class FaceGrid {
 
@@ -80,6 +80,14 @@ public class FaceGrid {
 
     public FaceGrid copy() {
         return new FaceGrid(cells, width, height, direction);
+    }
+
+    public byte[][] copyCells() {
+        byte[][] copy = new byte[height][width];
+        for (int y = 0; y < height; y++) {
+            System.arraycopy(cells[y], 0, copy[y], 0, width);
+        }
+        return copy;
     }
 
     @Override

--- a/src/main/java/pl/kosma/geodesy/solver/FaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/FaceSolver.java
@@ -1,0 +1,10 @@
+package pl.kosma.geodesy.solver;
+
+/**
+ * Interface for face solving algorithms.
+ * Takes a FaceGrid and computes optimal slime/honey block placement.
+ */
+@FunctionalInterface
+public interface FaceSolver {
+    SolverResult solve(FaceGrid input, SolverConfig config);
+}

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -1,0 +1,503 @@
+package pl.kosma.geodesy.solver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/*
+ * Optimized face solver using island-based backtracking algorithm.
+ *
+ * Finds optimal placement of "islands" (connected groups of slime/honey blocks)
+ * to cover harvest cells. Constraints:
+ * - Each island must be 4-12 cells in size
+ * - Each island must have an L-shape (required for flying machine mechanics)
+ * - Adjacent islands must have different colors (slime vs honey)
+ * - L-shapes of different islands cannot be adjacent
+ * - Islands cannot overlap or cover blocked cells
+ *
+ * Maximizes: ones_covered - (island_count * island_cost)
+ */
+public class IslandFaceSolver implements FaceSolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("IslandFaceSolver");
+
+    private static final int MIN_ISLAND_SIZE = 4;
+    private static final int MAX_ISLAND_SIZE = 12;
+    private static final int MAX_SHAPES_PER_TARGET = 1000;
+
+    // Grid state
+    private int[][] grid;
+    private int rows;
+    private int cols;
+    private int totalCells;
+    private double islandCost;
+    private long timeoutMs;
+    private long startTime;
+
+    // Target tracking
+    private List<int[]> targets;  // List of [row, col] for all 1s
+    private Map<Long, Integer> targetIndices;  // Map cell key -> index in targets
+
+    // Precomputed shapes: Map target_index -> list of Shape
+    private Map<Integer, List<Shape>> possibleShapes;
+
+    // Sorted target indices (by scarcity - fewest shapes first)
+    private int[] sortedTargetIndices;
+
+    // Best solution found
+    private List<Island> bestSolution;
+    private double maxScore;
+
+    private static final int[][] DIRECTIONS = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
+
+    private static class Shape {
+        final BitSet mask;
+        final int onesCovered;
+        final Set<Long> cells;
+
+        Shape(BitSet mask, int onesCovered, Set<Long> cells) {
+            this.mask = mask;
+            this.onesCovered = onesCovered;
+            this.cells = cells;
+        }
+    }
+
+    private static class Island {
+        final Set<Long> cells;
+        final Set<Long> lShapeCells;  // The 4 cells forming the L-shape
+        final int material;  // 0 = slime, 1 = honey
+
+        Island(Set<Long> cells, Set<Long> lShapeCells, int material) {
+            this.cells = cells;
+            this.lShapeCells = lShapeCells;
+            this.material = material;
+        }
+    }
+
+    @Override
+    public SolverResult solve(FaceGrid input, SolverConfig config) {
+        startTime = System.currentTimeMillis();
+        timeoutMs = config.getTimeoutMs();
+        islandCost = config.getCostThreshold();
+
+        // Convert FaceGrid to internal grid format
+        rows = input.getHeight();
+        cols = input.getWidth();
+        totalCells = rows * cols;
+        grid = new int[rows][cols];
+
+        for (int y = 0; y < rows; y++) {
+            for (int x = 0; x < cols; x++) {
+                grid[y][x] = input.getCell(x, y);
+            }
+        }
+
+        // Initialize state
+        targets = new ArrayList<>();
+        targetIndices = new HashMap<>();
+        possibleShapes = new HashMap<>();
+        bestSolution = new ArrayList<>();
+        maxScore = Double.NEGATIVE_INFINITY;
+
+        // Find all target cells
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                if (grid[r][c] == FaceGrid.CELL_HARVEST) {
+                    targetIndices.put(cellKey(r, c), targets.size());
+                    targets.add(new int[]{r, c});
+                }
+            }
+        }
+
+        if (targets.isEmpty()) {
+            LOGGER.info("No harvest cells to solve");
+            return SolverResult.empty(input);
+        }
+
+        LOGGER.info("Solving {}x{} grid with {} harvest cells", cols, rows, targets.size());
+
+        precomputeShapes();
+        backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, 0);
+
+        long solveTime = System.currentTimeMillis() - startTime;
+        boolean timedOut = solveTime >= timeoutMs;
+
+        return buildResult(input, solveTime, timedOut);
+    }
+
+    private long cellKey(int row, int col) {
+        return ((long) row << 16) | (col & 0xFFFF);
+    }
+
+    private int keyRow(long key) {
+        return (int) (key >> 16);
+    }
+
+    private int keyCol(long key) {
+        return (int) (key & 0xFFFF);
+    }
+
+    private int cellBit(int row, int col) {
+        return row * cols + col;
+    }
+
+    private BitSet getShapeMask(Set<Long> cells) {
+        BitSet mask = new BitSet(totalCells);
+        for (long key : cells) {
+            int bit = cellBit(keyRow(key), keyCol(key));
+            mask.set(bit);
+        }
+        return mask;
+    }
+
+    // An L-shape requires at least one cell to have neighbors in perpendicular directions.
+    private boolean hasLShape(Set<Long> cells) {
+        for (long key : cells) {
+            int r = keyRow(key);
+            int c = keyCol(key);
+
+            // Check for horizontal line segment (3 cells)
+            boolean hasLeft = cells.contains(cellKey(r, c - 1));
+            boolean hasRight = cells.contains(cellKey(r, c + 1));
+
+            if (hasLeft && hasRight) {
+                for (int dr : new int[]{-1, 1}) {
+                    for (int dc = -1; dc <= 1; dc++) {
+                        if (cells.contains(cellKey(r + dr, c + dc))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // Check for vertical line segment (3 cells)
+            boolean hasUp = cells.contains(cellKey(r - 1, c));
+            boolean hasDown = cells.contains(cellKey(r + 1, c));
+
+            if (hasUp && hasDown) {
+                for (int dr = -1; dr <= 1; dr++) {
+                    for (int dc : new int[]{-1, 1}) {
+                        if (cells.contains(cellKey(r + dr, c + dc))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void precomputeShapes() {
+        LOGGER.debug("Pre-computing shapes...");
+
+        Set<Set<Long>> seenShapesGlobal = new HashSet<>();
+
+        for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
+            possibleShapes.put(tIdx, new ArrayList<>());
+
+            int[] start = targets.get(tIdx);
+            long startKey = cellKey(start[0], start[1]);
+
+            // BFS to find shapes starting from this target
+            Queue<Set<Long>> queue = new LinkedList<>();
+            Set<Set<Long>> seenLocal = new HashSet<>();
+
+            Set<Long> initial = new HashSet<>();
+            initial.add(startKey);
+            queue.add(initial);
+            seenLocal.add(initial);
+
+            int shapesFound = 0;
+
+            while (!queue.isEmpty() && shapesFound < MAX_SHAPES_PER_TARGET) {
+                Set<Long> current = queue.poll();
+
+                if (current.size() < MAX_ISLAND_SIZE) {
+                    Set<Long> neighbors = new HashSet<>();
+
+                    for (long key : current) {
+                        int r = keyRow(key);
+                        int c = keyCol(key);
+
+                        for (int[] dir : DIRECTIONS) {
+                            int nr = r + dir[0];
+                            int nc = c + dir[1];
+
+                            if (nr >= 0 && nr < rows && nc >= 0 && nc < cols
+                                    && grid[nr][nc] != FaceGrid.CELL_BLOCKED) {
+                                long nkey = cellKey(nr, nc);
+                                if (!current.contains(nkey)) {
+                                    neighbors.add(nkey);
+                                }
+                            }
+                        }
+                    }
+
+                    for (long n : neighbors) {
+                        Set<Long> newShape = new HashSet<>(current);
+                        newShape.add(n);
+
+                        if (!seenLocal.contains(newShape)) {
+                            seenLocal.add(newShape);
+                            queue.add(newShape);
+
+                            if (newShape.size() >= MIN_ISLAND_SIZE && hasLShape(newShape)) {
+                                if (!seenShapesGlobal.contains(newShape)) {
+                                    seenShapesGlobal.add(newShape);
+
+                                    BitSet mask = getShapeMask(newShape);
+                                    int ones = 0;
+                                    for (long key : newShape) {
+                                        int r = keyRow(key);
+                                        int c = keyCol(key);
+                                        if (grid[r][c] == FaceGrid.CELL_HARVEST) {
+                                            ones++;
+                                        }
+                                    }
+
+                                    Shape shape = new Shape(mask, ones, new HashSet<>(newShape));
+
+                                    // Assign shape to every target it covers
+                                    for (long key : newShape) {
+                                        Integer ti = targetIndices.get(key);
+                                        if (ti != null) {
+                                            possibleShapes.computeIfAbsent(ti, k -> new ArrayList<>()).add(shape);
+                                        }
+                                    }
+
+                                    shapesFound++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sort targets by scarcity (fewest shapes first)
+        sortedTargetIndices = new int[targets.size()];
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < targets.size(); i++) {
+            indices.add(i);
+        }
+        indices.sort(Comparator.comparingInt(i -> possibleShapes.getOrDefault(i, Collections.emptyList()).size()));
+        for (int i = 0; i < indices.size(); i++) {
+            sortedTargetIndices[i] = indices.get(i);
+        }
+
+        LOGGER.debug("Found {} unique shapes", seenShapesGlobal.size());
+    }
+
+    private void backtrack(int sortedIdx, BitSet occupiedMask, List<Island> currentIslands,
+                           int currentOnes, int currentIslandsCount) {
+        if (System.currentTimeMillis() - startTime > timeoutMs) {
+            return;
+        }
+
+        // Base case: all targets considered
+        if (sortedIdx >= targets.size()) {
+            double score = currentOnes - (currentIslandsCount * islandCost);
+            if (score > maxScore) {
+                maxScore = score;
+                bestSolution = new ArrayList<>();
+                for (Island island : currentIslands) {
+                    bestSolution.add(new Island(
+                            new HashSet<>(island.cells),
+                            new HashSet<>(island.lShapeCells),
+                            island.material));
+                }
+            }
+            return;
+        }
+
+        int realTargetIdx = sortedTargetIndices[sortedIdx];
+        int[] targetPos = targets.get(realTargetIdx);
+        int targetBit = cellBit(targetPos[0], targetPos[1]);
+
+        // Pruning: target already covered?
+        if (occupiedMask.get(targetBit)) {
+            backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
+            return;
+        }
+
+        // Pruning: score estimation
+        int remainingTargets = 0;
+        for (int i = sortedIdx; i < targets.size(); i++) {
+            int ti = sortedTargetIndices[i];
+            int[] tp = targets.get(ti);
+            int bit = cellBit(tp[0], tp[1]);
+            if (!occupiedMask.get(bit)) {
+                remainingTargets++;
+            }
+        }
+
+        double currentScore = currentOnes - (currentIslandsCount * islandCost);
+        if (currentScore + remainingTargets <= maxScore) {
+            return;
+        }
+
+        List<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, Collections.emptyList());
+        shapes.sort((a, b) -> Integer.compare(b.onesCovered, a.onesCovered));
+
+        for (Shape shape : shapes) {
+            if (!occupiedMask.intersects(shape.mask)) {
+                Set<Long> newLShape = findLShapeCells(shape.cells);
+                if (newLShape == null) continue;
+
+                Set<Integer> adjColors = new HashSet<>();
+                boolean possible = true;
+
+                for (Island existing : currentIslands) {
+                    // L-shapes of different islands cannot be adjacent
+                    if (isAdjacent(newLShape, existing.lShapeCells)) {
+                        possible = false;
+                        break;
+                    }
+
+                    // Adjacent islands must have different colors
+                    if (isAdjacent(shape.cells, existing.cells)) {
+                        adjColors.add(existing.material);
+                        if (adjColors.size() >= 2) {
+                            possible = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (possible) {
+                    int color = adjColors.contains(0) ? 1 : 0;
+
+                    currentIslands.add(new Island(shape.cells, newLShape, color));
+
+                    BitSet newOccupied = (BitSet) occupiedMask.clone();
+                    newOccupied.or(shape.mask);
+
+                    backtrack(
+                            sortedIdx + 1,
+                            newOccupied,
+                            currentIslands,
+                            currentOnes + shape.onesCovered,
+                            currentIslandsCount + 1
+                    );
+
+                    currentIslands.remove(currentIslands.size() - 1);
+                }
+            }
+        }
+
+        // Option: skip this target
+        backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
+    }
+
+    private boolean isAdjacent(Set<Long> cells1, Set<Long> cells2) {
+        for (long key : cells1) {
+            int r = keyRow(key);
+            int c = keyCol(key);
+            for (int[] dir : DIRECTIONS) {
+                if (cells2.contains(cellKey(r + dir[0], c + dir[1]))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
+    private Set<Long> findLShapeCells(Set<Long> cells) {
+        for (long key : cells) {
+            int x = keyRow(key);
+            int y = keyCol(key);
+
+            for (int[] stemDir : DIRECTIONS) {
+                int prevX = x - stemDir[0];
+                int prevY = y - stemDir[1];
+                int nextX = x + stemDir[0];
+                int nextY = y + stemDir[1];
+
+                long prevKey = cellKey(prevX, prevY);
+                long nextKey = cellKey(nextX, nextY);
+
+                if (cells.contains(prevKey) && cells.contains(nextKey)) {
+                    for (int[] perpDir : DIRECTIONS) {
+                        if (perpDir[0] == stemDir[0] && perpDir[1] == stemDir[1]) continue;
+                        if (perpDir[0] == -stemDir[0] && perpDir[1] == -stemDir[1]) continue;
+
+                        // Check corner at prev end
+                        int cornerX = prevX + perpDir[0];
+                        int cornerY = prevY + perpDir[1];
+                        long cornerKey = cellKey(cornerX, cornerY);
+
+                        if (cells.contains(cornerKey)) {
+                            Set<Long> lShape = new HashSet<>();
+                            lShape.add(prevKey);
+                            lShape.add(key);
+                            lShape.add(nextKey);
+                            lShape.add(cornerKey);
+                            return lShape;
+                        }
+
+                        // Check corner at next end
+                        cornerX = nextX + perpDir[0];
+                        cornerY = nextY + perpDir[1];
+                        cornerKey = cellKey(cornerX, cornerY);
+
+                        if (cells.contains(cornerKey)) {
+                            Set<Long> lShape = new HashSet<>();
+                            lShape.add(prevKey);
+                            lShape.add(key);
+                            lShape.add(nextKey);
+                            lShape.add(cornerKey);
+                            return lShape;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private SolverResult buildResult(FaceGrid input, long solveTime, boolean timedOut) {
+        SolverResult.Builder builder = SolverResult.builder(input.getWidth(), input.getHeight(), input.getDirection())
+                .totalHarvest(input.getHarvestCount())
+                .solveTimeMs(solveTime)
+                .timedOut(timedOut);
+
+        Set<Long> coveredCells = new HashSet<>();
+        for (Island island : bestSolution) {
+            coveredCells.addAll(island.cells);
+        }
+
+        int harvestCovered = 0;
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                if (grid[r][c] == FaceGrid.CELL_HARVEST && coveredCells.contains(cellKey(r, c))) {
+                    harvestCovered++;
+                }
+            }
+        }
+        builder.harvestCovered(harvestCovered);
+
+        for (Island island : bestSolution) {
+            SolverResult.PlacementType type = (island.material == 0)
+                    ? SolverResult.PlacementType.SLIME
+                    : SolverResult.PlacementType.HONEY;
+
+            Set<int[]> resultCells = new HashSet<>();
+            for (long key : island.cells) {
+                int r = keyRow(key);
+                int c = keyCol(key);
+                // FaceGrid uses (x, y) where x=col, y=row
+                builder.setPlacement(c, r, type);
+                resultCells.add(new int[]{c, r});
+            }
+
+            builder.addIsland(new SolverResult.Island(resultCells, type));
+        }
+
+        LOGGER.info("Solution: {} islands, {} harvest covered, score={:.2f}",
+                bestSolution.size(), harvestCovered, maxScore);
+
+        return builder.build();
+    }
+}

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -113,7 +113,7 @@ public class IslandFaceSolver implements FaceSolver {
 
         precomputeShapes();
         sortShapes();
-        backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, 0);
+        backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, targets.size(), 0);
 
         long solveTime = System.currentTimeMillis() - startTime;
         boolean timedOut = solveTime >= timeoutMs;
@@ -287,20 +287,24 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     private void backtrack(int sortedIdx, BitSet occupiedMask, List<Island> currentIslands,
-                           int currentOnes, int currentIslandsCount) {
+                           int currentOnes, int remainingPossibleTargets, int currentIslandsCount) {
         if (System.currentTimeMillis() - startTime > timeoutMs) {
             return;
         }
 
+        double currentScore = currentOnes - (currentIslandsCount * islandCost);
+
         // Base case: all targets considered
         if (sortedIdx >= targets.size()) {
-            double score = currentOnes - (currentIslandsCount * islandCost);
-            if (score > maxScore) {
-                maxScore = score;
+            if (currentScore > maxScore) {
+                maxScore = currentScore;
                 bestSolution = new ArrayList<>(currentIslands);
             }
             return;
         }
+
+        // Pruning: score estimation
+        if (currentScore + remainingPossibleTargets <= maxScore) return;
 
         int realTargetIdx = sortedTargetIndices[sortedIdx];
         int targetKey = targets.getInt(realTargetIdx);
@@ -308,23 +312,9 @@ public class IslandFaceSolver implements FaceSolver {
 
         // Pruning: target already covered?
         if (occupiedMask.get(targetBit)) {
-            backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
+            backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, remainingPossibleTargets, currentIslandsCount);
             return;
         }
-
-        // Pruning: score estimation
-        int remainingTargets = 0;
-        for (int i = sortedIdx; i < targets.size(); i++) {
-            int ti = sortedTargetIndices[i];
-            int tkey = targets.getInt(ti);
-            int bit = cellBit(keyRow(tkey), keyCol(tkey));
-            if (!occupiedMask.get(bit)) {
-                remainingTargets++;
-            }
-        }
-
-        double currentScore = currentOnes - (currentIslandsCount * islandCost);
-        if (currentScore + remainingTargets <= maxScore) return;
 
         List<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, Collections.emptyList());
 
@@ -359,23 +349,24 @@ public class IslandFaceSolver implements FaceSolver {
             byte color = hasColor(adjColors, SLIME) ? HONEY : SLIME;
 
             currentIslands.add(new Island(shape.cells, shape.lShape, color));
-
-            BitSet newOccupied = (BitSet) occupiedMask.clone();
-            newOccupied.or(shape.mask);
+            occupiedMask.or(shape.mask);
 
             backtrack(
                     sortedIdx + 1,
-                    newOccupied,
+                    occupiedMask,
                     currentIslands,
                     currentOnes + shape.onesCovered,
+                    remainingPossibleTargets - shape.onesCovered,
                     currentIslandsCount + 1
             );
 
             currentIslands.removeLast();
+            occupiedMask.xor(shape.mask);
         }
 
         // Option: skip this target
-        backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
+        // There are no valid shapes that cover this target
+        backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, remainingPossibleTargets - 1, currentIslandsCount);
     }
 
     private boolean hasColor(byte colors, byte material) {

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -206,18 +206,19 @@ public class IslandFaceSolver implements FaceSolver {
 
             // BFS to find shapes starting from this target
             // Use ArrayDeque as a deque: harvest neighbors go to front, air to back
-            ArrayDeque<LongOpenHashSet> queue = new ArrayDeque<>();
+            ArrayDeque<LongOpenHashSet> queueHarvest = new ArrayDeque<>();
+            ArrayDeque<LongOpenHashSet> queueAir = new ArrayDeque<>();
             ObjectOpenHashSet<LongOpenHashSet> seenLocal = new ObjectOpenHashSet<>();
 
             LongOpenHashSet initial = new LongOpenHashSet();
             initial.add(startKey);
-            queue.add(initial);
+            queueHarvest.add(initial);
             seenLocal.add(initial);
 
             int shapesFound = 0;
 
-            while (!queue.isEmpty() && shapesFound < MAX_SHAPES_PER_TARGET) {
-                LongOpenHashSet current = queue.poll();
+            while ((!queueHarvest.isEmpty() || !queueAir.isEmpty()) && shapesFound < MAX_SHAPES_PER_TARGET) {
+                LongOpenHashSet current = !queueHarvest.isEmpty() ? queueHarvest.poll() : queueAir.poll();
 
                 if (current.size() < MAX_ISLAND_SIZE) {
                     LongOpenHashSet neighbors = new LongOpenHashSet();
@@ -251,9 +252,9 @@ public class IslandFaceSolver implements FaceSolver {
                             int nr = keyRow(n);
                             int nc = keyCol(n);
                             if (grid[nr][nc] == FaceGrid.CELL_HARVEST) {
-                                queue.addFirst(newShape);
+                                queueHarvest.add(newShape);
                             } else {
-                                queue.addLast(newShape);
+                                queueAir.add(newShape);
                             }
 
                             if (newShape.size() >= MIN_ISLAND_SIZE && hasLShape(newShape)) {

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -61,7 +61,7 @@ public class IslandFaceSolver implements FaceSolver {
     // Underflow will impact the upper 16 bits, but we rely on range checks on the lower 16 bits to catch that.
     private static final int[] DIRECTIONS = {cellKey(0, 1), -1, cellKey(1, 0), cellKey(-1, 0)};
 
-    private record Shape(BitSet mask, int onesCovered, IntSet cells, LShape lShape) {}
+    private record Shape(IntSet cells, BitSet mask, BitSet neighborsMask, int onesCovered, LShape lShape) {}
 
     /**
      * @param material    1 = slime, 2 = honey
@@ -72,7 +72,7 @@ public class IslandFaceSolver implements FaceSolver {
      * @param stemCells   the 3 cells forming the main stem of the L-shape
      * @param stopperCell the cell on the shorter leg of the L-shape
      */
-    public record LShape(IntSet stemCells, int stopperCell) {}
+    public record LShape(IntSet stemCells, BitSet stemMask, BitSet stemNeighborsMask, int stopperCell) {}
 
     @Override
     public SolverResult solve(FaceGrid input, SolverConfig config) {
@@ -113,7 +113,7 @@ public class IslandFaceSolver implements FaceSolver {
 
         precomputeShapes();
         sortShapes();
-        backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, targets.size(), 0);
+        backtrack(0, new ArrayList<>(), new BitSet(totalCells), new BitSet(totalCells), new BitSet(totalCells), 0, targets.size(), 0);
 
         long solveTime = System.currentTimeMillis() - startTime;
         boolean timedOut = solveTime >= timeoutMs;
@@ -226,7 +226,7 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
-    private static LShape findLShapeCells(IntSet cells) {
+    private LShape findLShapeCells(IntSet cells) {
         for (int key : cells) {
             for (int stemDir : DIRECTIONS) {
                 int prevKey = key - stemDir;
@@ -240,13 +240,15 @@ public class IslandFaceSolver implements FaceSolver {
                         // Check corner at prev end
                         int cornerKey = prevKey + perpDir;
                         if (cells.contains(cornerKey)) {
-                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
+                            IntSet stemCells = IntSet.of(prevKey, key, nextKey);
+                            return new LShape(stemCells, getMask(stemCells), getNeighborsMask(stemCells), cornerKey);
                         }
 
                         // Check corner at next end
                         cornerKey = nextKey + perpDir;
                         if (cells.contains(cornerKey)) {
-                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
+                            IntSet stemCells = IntSet.of(prevKey, key, nextKey);
+                            return new LShape(stemCells, getMask(stemCells), getNeighborsMask(stemCells), cornerKey);
                         }
                     }
                 }
@@ -256,22 +258,43 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     private Shape createShape(IntSet newShape, LShape lShape) {
-        BitSet mask = new BitSet(totalCells);
         int ones = 0;
 
         for (int key : newShape) {
             int r = keyRow(key);
             int c = keyCol(key);
-
-            int bit = cellBit(r, c);
-            mask.set(bit);
-
             if (grid[r][c] == FaceGrid.CELL_HARVEST) {
                 ones++;
             }
         }
 
-        return new Shape(mask, ones, newShape, lShape);
+        return new Shape(newShape, getMask(newShape), getNeighborsMask(newShape), ones, lShape);
+    }
+
+    private BitSet getMask(IntSet cells) {
+        BitSet mask = new BitSet();
+        for (int key : cells) {
+            int r = keyRow(key);
+            int c = keyCol(key);
+            mask.set(cellBit(r, c));
+        }
+        return mask;
+    }
+
+    private BitSet getNeighborsMask(IntSet shape) {
+        BitSet neighborsMask = new BitSet();
+        for (int key : shape) {
+            int r = keyRow(key);
+            int c = keyCol(key);
+            for (int dir : DIRECTIONS) {
+                int nr = r + keyRow(dir);
+                int nc = c + keyCol(dir);
+                if (nr >= 0 && nr < rows && nc >= 0 && nc < cols) {
+                    neighborsMask.set(cellBit(nr, nc));
+                }
+            }
+        }
+        return neighborsMask;
     }
 
     private void sortShapes() {
@@ -286,7 +309,8 @@ public class IslandFaceSolver implements FaceSolver {
         }
     }
 
-    private void backtrack(int sortedIdx, BitSet occupiedMask, List<Island> currentIslands,
+    private void backtrack(int sortedIdx, List<Island> currentIslands,
+                           BitSet slimeMask, BitSet honeyMask, BitSet lShapeStemMask,
                            int currentOnes, int remainingPossibleTargets, int currentIslandsCount) {
         if (System.currentTimeMillis() - startTime > timeoutMs) {
             return;
@@ -311,81 +335,65 @@ public class IslandFaceSolver implements FaceSolver {
         int targetBit = cellBit(keyRow(targetKey), keyCol(targetKey));
 
         // Pruning: target already covered?
-        if (occupiedMask.get(targetBit)) {
-            backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, remainingPossibleTargets, currentIslandsCount);
+        if (slimeMask.get(targetBit) || honeyMask.get(targetBit)) {
+            backtrack(sortedIdx + 1, currentIslands, slimeMask, honeyMask, lShapeStemMask, currentOnes, remainingPossibleTargets, currentIslandsCount);
             return;
         }
 
         List<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, Collections.emptyList());
 
         for (Shape shape : shapes) {
-            if (occupiedMask.intersects(shape.mask)) continue;
+            if (slimeMask.intersects(shape.mask) || honeyMask.intersects(shape.mask)) continue;
 
-            byte adjColors = 0;
-            boolean possible = true;
+            // L-shapes contain the flying machine mechanism (pistons + slime/honey).
+            // Even though adjacent islands use different materials, adjacent L-shapes
+            // would cause mechanical interference during piston extension — the
+            // flying machines would push/pull each other's components.
+            if (isAdjacent(lShapeStemMask, shape.lShape)) continue;
 
-            for (Island existing : currentIslands) {
-                // L-shapes contain the flying machine mechanism (pistons + slime/honey).
-                // Even though adjacent islands use different materials, adjacent L-shapes
-                // would cause mechanical interference during piston extension — the
-                // flying machines would push/pull each other's components.
-                if (isAdjacent(shape.lShape, existing.lShape)) {
-                    possible = false;
-                    break;
-                }
+            // Check if this shape would be adjacent to both slime and honey islands, which is not allowed
+            boolean slimeAdj = isAdjacent(slimeMask, shape);
+            if (slimeAdj && isAdjacent(honeyMask, shape)) continue;
 
-                // Adjacent islands must have different colors
-                if (isAdjacent(shape.cells, existing.cells)) {
-                    adjColors |= (byte) (1 << existing.material);
-                    if (hasColor(adjColors, SLIME) && hasColor(adjColors, HONEY)) {
-                        possible = false;
-                        break;
-                    }
-                }
-            }
-
-            if (!possible) continue;
-
-            byte color = hasColor(adjColors, SLIME) ? HONEY : SLIME;
+            byte color = slimeAdj ? HONEY : SLIME;
 
             currentIslands.add(new Island(shape.cells, shape.lShape, color));
-            occupiedMask.or(shape.mask);
+            if (slimeAdj) honeyMask.or(shape.mask);
+            else slimeMask.or(shape.mask);
+            lShapeStemMask.or(shape.lShape.stemMask);
 
             backtrack(
                     sortedIdx + 1,
-                    occupiedMask,
                     currentIslands,
+                    slimeMask,
+                    honeyMask,
+                    lShapeStemMask,
                     currentOnes + shape.onesCovered,
                     remainingPossibleTargets - shape.onesCovered,
                     currentIslandsCount + 1
             );
 
             currentIslands.removeLast();
-            occupiedMask.xor(shape.mask);
+            if (slimeAdj) honeyMask.andNot(shape.mask);
+            else slimeMask.andNot(shape.mask);
+            lShapeStemMask.andNot(shape.lShape.stemMask);
         }
 
         // Option: skip this target
         // There are no valid shapes that cover this target
-        backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, remainingPossibleTargets - 1, currentIslandsCount);
+        backtrack(sortedIdx + 1, currentIslands, slimeMask, honeyMask, lShapeStemMask, currentOnes, remainingPossibleTargets - 1, currentIslandsCount);
     }
 
     private boolean hasColor(byte colors, byte material) {
         return (colors & (1 << material)) != 0;
     }
 
-    private boolean isAdjacent(LShape cells1, LShape cells2) {
-        return isAdjacent(cells1.stemCells, cells2.stemCells);
+    private boolean isAdjacent(BitSet lShapeStemMask, LShape newLShape) {
+        return lShapeStemMask.intersects(newLShape.stemNeighborsMask);
     }
 
-    private boolean isAdjacent(IntSet cells1, IntSet cells2) {
-        for (int key : cells1) {
-            for (int dir : DIRECTIONS) {
-                if (cells2.contains(key + dir)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    private boolean isAdjacent(BitSet cellsMask, Shape newShape) {
+        return cellsMask.intersects(newShape.neighborsMask);
     }
 
     private SolverResult buildResult(FaceGrid input, long solveTime, boolean timedOut) {

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -274,7 +274,7 @@ public class IslandFaceSolver implements FaceSolver {
             }
         }
 
-        return new Shape(mask, ones, new IntOpenHashSet(newShape));
+        return new Shape(mask, ones, newShape);
     }
 
     private void sortShapes() {
@@ -300,10 +300,7 @@ public class IslandFaceSolver implements FaceSolver {
             double score = currentOnes - (currentIslandsCount * islandCost);
             if (score > maxScore) {
                 maxScore = score;
-                bestSolution = new ArrayList<>();
-                for (Island island : currentIslands) {
-                    bestSolution.add(new Island(new IntOpenHashSet(island.cells), island.lShape, island.material));
-                }
+                bestSolution = new ArrayList<>(currentIslands);
             }
             return;
         }

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -81,8 +81,8 @@ public class IslandFaceSolver implements FaceSolver {
         timeoutMs = config.getTimeoutMs();
         islandCost = config.getCostThreshold();
 
-        rows = input.getWidth();
-        cols = input.getHeight();
+        rows = input.width();
+        cols = input.height();
         totalCells = rows * cols;
         grid = input.copyCells();
 
@@ -433,7 +433,7 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     private SolverResult buildResult(FaceGrid input, long solveTime, boolean timedOut) {
-        SolverResult.Builder builder = SolverResult.builder(input.getWidth(), input.getHeight(), input.getDirection())
+        SolverResult.Builder builder = SolverResult.builder(input.width(), input.height(), input.direction())
                 .totalHarvest(input.getHarvestCount())
                 .solveTimeMs(solveTime)
                 .timedOut(timedOut);

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -3,10 +3,7 @@ package pl.kosma.geodesy.solver;
 import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
 import it.unimi.dsi.fastutil.bytes.ByteSet;
 import it.unimi.dsi.fastutil.ints.*;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet;
-import it.unimi.dsi.fastutil.objects.ObjectSet;
-import it.unimi.dsi.fastutil.objects.ObjectSortedSets;
+import it.unimi.dsi.fastutil.objects.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +49,7 @@ public class IslandFaceSolver implements FaceSolver {
     private Int2IntOpenHashMap targetIndices;  // Map cell key -> index in targets
 
     // Precomputed shapes: Map target_index -> list of Shape
-    private Int2ObjectOpenHashMap<SortedSet<Shape>> possibleShapes;
+    private Int2ObjectOpenHashMap<List<Shape>> possibleShapes;
 
     // Sorted target indices (by scarcity - fewest shapes first)
     private int[] sortedTargetIndices;
@@ -116,6 +113,7 @@ public class IslandFaceSolver implements FaceSolver {
         LOGGER.info("Solving {}x{} grid with {} harvest cells", rows, cols, targets.size());
 
         precomputeShapes();
+        sortShapes();
         backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, 0);
 
         long solveTime = System.currentTimeMillis() - startTime;
@@ -147,7 +145,7 @@ public class IslandFaceSolver implements FaceSolver {
         ObjectSet<IntSet> seenShapesGlobal = new ObjectOpenHashSet<>();
 
         for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
-            possibleShapes.put(tIdx, new ObjectRBTreeSet<>(SHAPE_PRIORITY_COMPARATOR));
+            possibleShapes.computeIfAbsent(tIdx, k -> new ArrayList<>());
 
             int start = targets.getInt(tIdx);
 
@@ -194,24 +192,13 @@ public class IslandFaceSolver implements FaceSolver {
                     for (int key : newShape) {
                         int ti = targetIndices.get(key);
                         if (ti != -1) {
-                            possibleShapes.computeIfAbsent(ti, k -> new ObjectRBTreeSet<>(SHAPE_PRIORITY_COMPARATOR)).add(shape);
+                            possibleShapes.computeIfAbsent(ti, k -> new ArrayList<>()).add(shape);
                         }
                     }
 
                     shapesFound++;
                 }
             }
-        }
-
-        // Sort targets by scarcity (fewest shapes first)
-        sortedTargetIndices = new int[targets.size()];
-        IntList indices = new IntArrayList();
-        for (int i = 0; i < targets.size(); i++) {
-            indices.add(i);
-        }
-        indices.sort(IntComparator.comparingInt(i -> possibleShapes.getOrDefault(i, ObjectSortedSets.emptySet()).size()));
-        for (int i = 0; i < indices.size(); i++) {
-            sortedTargetIndices[i] = indices.getInt(i);
         }
 
         LOGGER.debug("Found {} unique shapes", seenShapesGlobal.size());
@@ -290,6 +277,18 @@ public class IslandFaceSolver implements FaceSolver {
         return new Shape(mask, ones, new IntOpenHashSet(newShape));
     }
 
+    private void sortShapes() {
+        sortedTargetIndices = new int[targets.size()];
+        for (int i = 0; i < targets.size(); i++) {
+            sortedTargetIndices[i] = i;
+        }
+        IntArrays.quickSort(sortedTargetIndices, IntComparator.comparingInt(i -> possibleShapes.getOrDefault(i, Collections.emptyList()).size()));
+
+        for (List<Shape> possibleShapes : possibleShapes.values()) {
+            possibleShapes.sort(SHAPE_PRIORITY_COMPARATOR);
+        }
+    }
+
     private void backtrack(int sortedIdx, BitSet occupiedMask, List<Island> currentIslands,
                            int currentOnes, int currentIslandsCount) {
         if (System.currentTimeMillis() - startTime > timeoutMs) {
@@ -303,10 +302,7 @@ public class IslandFaceSolver implements FaceSolver {
                 maxScore = score;
                 bestSolution = new ArrayList<>();
                 for (Island island : currentIslands) {
-                    bestSolution.add(new Island(
-                            new IntOpenHashSet(island.cells) {},
-                            island.lShape,
-                            island.material));
+                    bestSolution.add(new Island(new IntOpenHashSet(island.cells), island.lShape, island.material));
                 }
             }
             return;
@@ -336,7 +332,7 @@ public class IslandFaceSolver implements FaceSolver {
         double currentScore = currentOnes - (currentIslandsCount * islandCost);
         if (currentScore + remainingTargets <= maxScore) return;
 
-        SortedSet<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, ObjectSortedSets.emptySet());
+        List<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, Collections.emptyList());
 
         for (Shape shape : shapes) {
             if (occupiedMask.intersects(shape.mask)) continue;

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -1,9 +1,12 @@
 package pl.kosma.geodesy.solver;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
+import it.unimi.dsi.fastutil.bytes.ByteSet;
+import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import it.unimi.dsi.fastutil.objects.ObjectSortedSets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +33,9 @@ public class IslandFaceSolver implements FaceSolver {
     private static final int MAX_ISLAND_SIZE = 12;
     private static final int MAX_SHAPES_PER_TARGET = 1000;
 
+    public static final byte SLIME = 1;
+    public static final byte HONEY = 2;
+
     // Grid state
     private byte[][] grid;
     private int rows;
@@ -40,11 +46,11 @@ public class IslandFaceSolver implements FaceSolver {
     private long startTime;
 
     // Target tracking
-    private List<int[]> targets;  // List of [row, col] for all 1s
-    private Long2IntOpenHashMap targetIndices;  // Map cell key -> index in targets
+    private IntList targets;  // List of [row, col] for all 1s
+    private Int2IntOpenHashMap targetIndices;  // Map cell key -> index in targets
 
     // Precomputed shapes: Map target_index -> list of Shape
-    private Int2ObjectOpenHashMap<List<Shape>> possibleShapes;
+    private Int2ObjectOpenHashMap<SortedSet<Shape>> possibleShapes;
 
     // Sorted target indices (by scarcity - fewest shapes first)
     private int[] sortedTargetIndices;
@@ -55,29 +61,18 @@ public class IslandFaceSolver implements FaceSolver {
 
     private static final int[][] DIRECTIONS = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
 
-    private static class Shape {
-        final BitSet mask;
-        final int onesCovered;
-        final LongOpenHashSet cells;
+    private record Shape(BitSet mask, int onesCovered, IntSet cells) {}
 
-        Shape(BitSet mask, int onesCovered, LongOpenHashSet cells) {
-            this.mask = mask;
-            this.onesCovered = onesCovered;
-            this.cells = cells;
-        }
-    }
+    /**
+     * @param material    1 = slime, 2 = honey
+     */
+    public record Island(IntSet cells, LShape lShape, byte material) {}
 
-    private static class Island {
-        final LongOpenHashSet cells;
-        final LongOpenHashSet lShapeCells;  // The 4 cells forming the L-shape
-        final int material;  // 0 = slime, 1 = honey
-
-        Island(LongOpenHashSet cells, LongOpenHashSet lShapeCells, int material) {
-            this.cells = cells;
-            this.lShapeCells = lShapeCells;
-            this.material = material;
-        }
-    }
+    /**
+     * @param stemCells   the 3 cells forming the main stem of the L-shape
+     * @param stopperCell the cell on the shorter leg of the L-shape
+     */
+    public record LShape(IntSet stemCells, int stopperCell) {}
 
     @Override
     public SolverResult solve(FaceGrid input, SolverConfig config) {
@@ -89,17 +84,11 @@ public class IslandFaceSolver implements FaceSolver {
         rows = input.getHeight();
         cols = input.getWidth();
         totalCells = rows * cols;
-        grid = new byte[rows][cols];
-
-        for (int y = 0; y < rows; y++) {
-            for (int x = 0; x < cols; x++) {
-                grid[y][x] = input.getCell(x, y);
-            }
-        }
+        grid = input.copyCells();
 
         // Initialize state
-        targets = new ArrayList<>();
-        targetIndices = new Long2IntOpenHashMap();
+        targets = new IntArrayList();
+        targetIndices = new Int2IntOpenHashMap();
         targetIndices.defaultReturnValue(-1);
         possibleShapes = new Int2ObjectOpenHashMap<>();
         bestSolution = new ArrayList<>();
@@ -109,8 +98,9 @@ public class IslandFaceSolver implements FaceSolver {
         for (int r = 0; r < rows; r++) {
             for (int c = 0; c < cols; c++) {
                 if (grid[r][c] == FaceGrid.CELL_HARVEST) {
-                    targetIndices.put(cellKey(r, c), targets.size());
-                    targets.add(new int[]{r, c});
+                    int key = cellKey(r, c);
+                    targetIndices.put(key, targets.size());
+                    targets.add(key);
                 }
             }
         }
@@ -131,34 +121,120 @@ public class IslandFaceSolver implements FaceSolver {
         return buildResult(input, solveTime, timedOut);
     }
 
-    private long cellKey(int row, int col) {
-        return ((long) row << 16) | (col & 0xFFFF);
+    private static int cellKey(int row, int col) {
+        return (row << 16) | (col & 0xFFFF);
     }
 
-    private int keyRow(long key) {
-        return (int) (key >> 16);
+    public static int keyRow(int key) {
+        return key >> 16;
     }
 
-    private int keyCol(long key) {
-        return (int) (key & 0xFFFF);
+    public static int keyCol(int key) {
+        return key & 0xFFFF;
     }
 
     private int cellBit(int row, int col) {
         return row * cols + col;
     }
 
-    private BitSet getShapeMask(LongOpenHashSet cells) {
-        BitSet mask = new BitSet(totalCells);
-        for (long key : cells) {
-            int bit = cellBit(keyRow(key), keyCol(key));
-            mask.set(bit);
+    private void precomputeShapes() {
+        LOGGER.debug("Pre-computing shapes...");
+
+        ObjectSet<IntSet> seenShapesGlobal = new ObjectOpenHashSet<>();
+
+        for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
+            possibleShapes.put(tIdx, new ObjectRBTreeSet<>(Comparator.comparingInt(Shape::onesCovered)));
+
+            int start = targets.getInt(tIdx);
+
+            // BFS to find shapes starting from this target
+            ArrayDeque<IntSet> queueHarvest = new ArrayDeque<>();
+            ArrayDeque<IntSet> queueAir = new ArrayDeque<>();
+            ObjectSet<IntSet> seenLocal = new ObjectOpenHashSet<>();
+
+            IntSet initial = new IntOpenHashSet();
+            initial.add(start);
+            queueHarvest.add(initial);
+            seenLocal.add(initial);
+
+            int shapesFound = 0;
+
+            while ((!queueHarvest.isEmpty() || !queueAir.isEmpty()) && shapesFound < MAX_SHAPES_PER_TARGET) {
+                IntSet current = !queueHarvest.isEmpty() ? queueHarvest.poll() : queueAir.poll();
+
+                if (current.size() >= MAX_ISLAND_SIZE) continue;
+                IntSet neighbors = getNeighbors(current);
+
+                for (int n : neighbors) {
+                    IntSet newShape = new IntOpenHashSet(current);
+                    newShape.add(n);
+
+                    if (!seenLocal.add(newShape)) continue;
+
+                    // We have not seen this shape locally
+                    // Prioritize harvest-cell neighbors
+                    int nr = keyRow(n);
+                    int nc = keyCol(n);
+                    if (grid[nr][nc] == FaceGrid.CELL_HARVEST) {
+                        queueHarvest.add(newShape);
+                    } else {
+                        queueAir.add(newShape);
+                    }
+
+                    if (newShape.size() < MIN_ISLAND_SIZE || !hasLShape(newShape) || !seenShapesGlobal.add(newShape)) continue;
+
+                    // We have not seen this shape globally
+                    Shape shape = createShape(newShape);
+
+                    // Assign shape to every target it covers
+                    for (int key : newShape) {
+                        int ti = targetIndices.get(key);
+                        if (ti != -1) {
+                            possibleShapes.computeIfAbsent(ti, k -> new ObjectRBTreeSet<>(Comparator.comparingInt(Shape::onesCovered))).add(shape);
+                        }
+                    }
+
+                    shapesFound++;
+                }
+            }
         }
-        return mask;
+
+        // Sort targets by scarcity (fewest shapes first)
+        sortedTargetIndices = new int[targets.size()];
+        IntList indices = new IntArrayList();
+        for (int i = 0; i < targets.size(); i++) {
+            indices.add(i);
+        }
+        indices.sort(IntComparator.comparingInt(i -> possibleShapes.getOrDefault(i, ObjectSortedSets.emptySet()).size()));
+        for (int i = 0; i < indices.size(); i++) {
+            sortedTargetIndices[i] = indices.getInt(i);
+        }
+
+        LOGGER.debug("Found {} unique shapes", seenShapesGlobal.size());
+    }
+
+    private IntSet getNeighbors(IntSet current) {
+        IntSet neighbors = new IntOpenHashSet();
+
+        for (int key : current) {
+            int r = keyRow(key);
+            int c = keyCol(key);
+
+            for (int[] dir : DIRECTIONS) {
+                int nr = r + dir[0];
+                int nc = c + dir[1];
+
+                if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && grid[nr][nc] != FaceGrid.CELL_BLOCKED) {
+                    neighbors.add(cellKey(nr, nc));
+                }
+            }
+        }
+        return neighbors;
     }
 
     // An L-shape requires at least one cell to have neighbors in perpendicular directions.
-    private boolean hasLShape(LongOpenHashSet cells) {
-        for (long key : cells) {
+    private boolean hasLShape(IntSet cells) {
+        for (int key : cells) {
             int r = keyRow(key);
             int c = keyCol(key);
 
@@ -193,115 +269,23 @@ public class IslandFaceSolver implements FaceSolver {
         return false;
     }
 
-    private void precomputeShapes() {
-        LOGGER.debug("Pre-computing shapes...");
+    private Shape createShape(IntSet newShape) {
+        BitSet mask = new BitSet(totalCells);
+        int ones = 0;
 
-        ObjectOpenHashSet<LongOpenHashSet> seenShapesGlobal = new ObjectOpenHashSet<>();
+        for (int key : newShape) {
+            int r = keyRow(key);
+            int c = keyCol(key);
 
-        for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
-            possibleShapes.put(tIdx, new ArrayList<>());
+            int bit = cellBit(r, c);
+            mask.set(bit);
 
-            int[] start = targets.get(tIdx);
-            long startKey = cellKey(start[0], start[1]);
-
-            // BFS to find shapes starting from this target
-            // Use ArrayDeque as a deque: harvest neighbors go to front, air to back
-            ArrayDeque<LongOpenHashSet> queueHarvest = new ArrayDeque<>();
-            ArrayDeque<LongOpenHashSet> queueAir = new ArrayDeque<>();
-            ObjectOpenHashSet<LongOpenHashSet> seenLocal = new ObjectOpenHashSet<>();
-
-            LongOpenHashSet initial = new LongOpenHashSet();
-            initial.add(startKey);
-            queueHarvest.add(initial);
-            seenLocal.add(initial);
-
-            int shapesFound = 0;
-
-            while ((!queueHarvest.isEmpty() || !queueAir.isEmpty()) && shapesFound < MAX_SHAPES_PER_TARGET) {
-                LongOpenHashSet current = !queueHarvest.isEmpty() ? queueHarvest.poll() : queueAir.poll();
-
-                if (current.size() < MAX_ISLAND_SIZE) {
-                    LongOpenHashSet neighbors = new LongOpenHashSet();
-
-                    for (long key : current) {
-                        int r = keyRow(key);
-                        int c = keyCol(key);
-
-                        for (int[] dir : DIRECTIONS) {
-                            int nr = r + dir[0];
-                            int nc = c + dir[1];
-
-                            if (nr >= 0 && nr < rows && nc >= 0 && nc < cols
-                                    && grid[nr][nc] != FaceGrid.CELL_BLOCKED) {
-                                long nkey = cellKey(nr, nc);
-                                if (!current.contains(nkey)) {
-                                    neighbors.add(nkey);
-                                }
-                            }
-                        }
-                    }
-
-                    for (long n : neighbors) {
-                        LongOpenHashSet newShape = new LongOpenHashSet(current);
-                        newShape.add(n);
-
-                        if (!seenLocal.contains(newShape)) {
-                            seenLocal.add(newShape);
-
-                            // Prioritize harvest-cell neighbors: add to front of queue
-                            int nr = keyRow(n);
-                            int nc = keyCol(n);
-                            if (grid[nr][nc] == FaceGrid.CELL_HARVEST) {
-                                queueHarvest.add(newShape);
-                            } else {
-                                queueAir.add(newShape);
-                            }
-
-                            if (newShape.size() >= MIN_ISLAND_SIZE && hasLShape(newShape)) {
-                                if (!seenShapesGlobal.contains(newShape)) {
-                                    seenShapesGlobal.add(newShape);
-
-                                    BitSet mask = getShapeMask(newShape);
-                                    int ones = 0;
-                                    for (long key : newShape) {
-                                        int r = keyRow(key);
-                                        int c = keyCol(key);
-                                        if (grid[r][c] == FaceGrid.CELL_HARVEST) {
-                                            ones++;
-                                        }
-                                    }
-
-                                    Shape shape = new Shape(mask, ones, new LongOpenHashSet(newShape));
-
-                                    // Assign shape to every target it covers
-                                    for (long key : newShape) {
-                                        int ti = targetIndices.get(key);
-                                        if (ti != -1) {
-                                            possibleShapes.computeIfAbsent(ti, k -> new ArrayList<>()).add(shape);
-                                        }
-                                    }
-
-                                    shapesFound++;
-                                }
-                            }
-                        }
-                    }
-                }
+            if (grid[r][c] == FaceGrid.CELL_HARVEST) {
+                ones++;
             }
         }
 
-        // Sort targets by scarcity (fewest shapes first)
-        sortedTargetIndices = new int[targets.size()];
-        List<Integer> indices = new ArrayList<>();
-        for (int i = 0; i < targets.size(); i++) {
-            indices.add(i);
-        }
-        indices.sort(Comparator.comparingInt(i -> possibleShapes.getOrDefault(i, Collections.emptyList()).size()));
-        for (int i = 0; i < indices.size(); i++) {
-            sortedTargetIndices[i] = indices.get(i);
-        }
-
-        LOGGER.debug("Found {} unique shapes", seenShapesGlobal.size());
+        return new Shape(mask, ones, new IntOpenHashSet(newShape));
     }
 
     private void backtrack(int sortedIdx, BitSet occupiedMask, List<Island> currentIslands,
@@ -318,8 +302,8 @@ public class IslandFaceSolver implements FaceSolver {
                 bestSolution = new ArrayList<>();
                 for (Island island : currentIslands) {
                     bestSolution.add(new Island(
-                            new LongOpenHashSet(island.cells),
-                            new LongOpenHashSet(island.lShapeCells),
+                            new IntOpenHashSet(island.cells) {},
+                            island.lShape,
                             island.material));
                 }
             }
@@ -327,8 +311,8 @@ public class IslandFaceSolver implements FaceSolver {
         }
 
         int realTargetIdx = sortedTargetIndices[sortedIdx];
-        int[] targetPos = targets.get(realTargetIdx);
-        int targetBit = cellBit(targetPos[0], targetPos[1]);
+        int targetKey = targets.getInt(realTargetIdx);
+        int targetBit = cellBit(keyRow(targetKey), keyCol(targetKey));
 
         // Pruning: target already covered?
         if (occupiedMask.get(targetBit)) {
@@ -340,28 +324,25 @@ public class IslandFaceSolver implements FaceSolver {
         int remainingTargets = 0;
         for (int i = sortedIdx; i < targets.size(); i++) {
             int ti = sortedTargetIndices[i];
-            int[] tp = targets.get(ti);
-            int bit = cellBit(tp[0], tp[1]);
+            int tkey = targets.getInt(ti);
+            int bit = cellBit(keyRow(tkey), keyCol(tkey));
             if (!occupiedMask.get(bit)) {
                 remainingTargets++;
             }
         }
 
         double currentScore = currentOnes - (currentIslandsCount * islandCost);
-        if (currentScore + remainingTargets <= maxScore) {
-            return;
-        }
+        if (currentScore + remainingTargets <= maxScore) return;
 
-        List<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, Collections.emptyList());
-        shapes.sort((a, b) -> Integer.compare(b.onesCovered, a.onesCovered));
+        SortedSet<Shape> shapes = possibleShapes.getOrDefault(realTargetIdx, ObjectSortedSets.emptySet());
 
         for (Shape shape : shapes) {
             if (occupiedMask.intersects(shape.mask)) continue;
 
-            LongOpenHashSet newLShape = findLShapeCells(shape.cells);
+            LShape newLShape = findLShapeCells(shape.cells);
             if (newLShape == null) continue;
 
-            Set<Integer> adjColors = new HashSet<>();
+            ByteSet adjColors = new ByteOpenHashSet();
             boolean possible = true;
 
             for (Island existing : currentIslands) {
@@ -369,7 +350,7 @@ public class IslandFaceSolver implements FaceSolver {
                 // Even though adjacent islands use different materials, adjacent L-shapes
                 // would cause mechanical interference during piston extension — the
                 // flying machines would push/pull each other's components.
-                if (isAdjacent(newLShape, existing.lShapeCells)) {
+                if (isAdjacent(newLShape, existing.lShape)) {
                     possible = false;
                     break;
                 }
@@ -386,7 +367,7 @@ public class IslandFaceSolver implements FaceSolver {
 
             if (!possible) continue;
 
-            int color = adjColors.contains(0) ? 1 : 0;
+            byte color = adjColors.contains(SLIME) ? HONEY : SLIME;
 
             currentIslands.add(new Island(shape.cells, newLShape, color));
 
@@ -401,15 +382,19 @@ public class IslandFaceSolver implements FaceSolver {
                     currentIslandsCount + 1
             );
 
-            currentIslands.remove(currentIslands.size() - 1);
+            currentIslands.removeLast();
         }
 
         // Option: skip this target
         backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
     }
 
-    private boolean isAdjacent(LongOpenHashSet cells1, LongOpenHashSet cells2) {
-        for (long key : cells1) {
+    private boolean isAdjacent(LShape cells1, LShape cells2) {
+        return isAdjacent(cells1.stemCells, cells2.stemCells);
+    }
+
+    private boolean isAdjacent(IntSet cells1, IntSet cells2) {
+        for (int key : cells1) {
             int r = keyRow(key);
             int c = keyCol(key);
             for (int[] dir : DIRECTIONS) {
@@ -422,8 +407,8 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
-    private LongOpenHashSet findLShapeCells(LongOpenHashSet cells) {
-        for (long key : cells) {
+    private LShape findLShapeCells(IntSet cells) {
+        for (int key : cells) {
             int x = keyRow(key);
             int y = keyCol(key);
 
@@ -433,8 +418,8 @@ public class IslandFaceSolver implements FaceSolver {
                 int nextX = x + stemDir[0];
                 int nextY = y + stemDir[1];
 
-                long prevKey = cellKey(prevX, prevY);
-                long nextKey = cellKey(nextX, nextY);
+                int prevKey = cellKey(prevX, prevY);
+                int nextKey = cellKey(nextX, nextY);
 
                 if (cells.contains(prevKey) && cells.contains(nextKey)) {
                     for (int[] perpDir : DIRECTIONS) {
@@ -444,15 +429,10 @@ public class IslandFaceSolver implements FaceSolver {
                         // Check corner at prev end
                         int cornerX = prevX + perpDir[0];
                         int cornerY = prevY + perpDir[1];
-                        long cornerKey = cellKey(cornerX, cornerY);
+                        int cornerKey = cellKey(cornerX, cornerY);
 
                         if (cells.contains(cornerKey)) {
-                            LongOpenHashSet lShape = new LongOpenHashSet();
-                            lShape.add(prevKey);
-                            lShape.add(key);
-                            lShape.add(nextKey);
-                            lShape.add(cornerKey);
-                            return lShape;
+                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }
 
                         // Check corner at next end
@@ -461,12 +441,7 @@ public class IslandFaceSolver implements FaceSolver {
                         cornerKey = cellKey(cornerX, cornerY);
 
                         if (cells.contains(cornerKey)) {
-                            LongOpenHashSet lShape = new LongOpenHashSet();
-                            lShape.add(prevKey);
-                            lShape.add(key);
-                            lShape.add(nextKey);
-                            lShape.add(cornerKey);
-                            return lShape;
+                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }
                     }
                 }
@@ -481,7 +456,7 @@ public class IslandFaceSolver implements FaceSolver {
                 .solveTimeMs(solveTime)
                 .timedOut(timedOut);
 
-        LongOpenHashSet coveredCells = new LongOpenHashSet();
+        IntSet coveredCells = new IntOpenHashSet();
         for (Island island : bestSolution) {
             coveredCells.addAll(island.cells);
         }
@@ -497,28 +472,14 @@ public class IslandFaceSolver implements FaceSolver {
         builder.harvestCovered(harvestCovered);
 
         for (Island island : bestSolution) {
-            SolverResult.PlacementType type = (island.material == 0)
-                    ? SolverResult.PlacementType.SLIME
-                    : SolverResult.PlacementType.HONEY;
-
-            Set<int[]> resultCells = new HashSet<>();
-            for (long key : island.cells) {
+            for (int key : island.cells) {
                 int r = keyRow(key);
                 int c = keyCol(key);
                 // FaceGrid uses (x, y) where x=col, y=row
-                builder.setPlacement(c, r, type);
-                resultCells.add(new int[]{c, r});
+                builder.setPlacement(c, r, island.material);
             }
 
-            // Convert internal L-shape cells to [x, y] coordinates for SolverResult
-            Set<int[]> resultLShapeCells = new HashSet<>();
-            for (long key : island.lShapeCells) {
-                int r = keyRow(key);
-                int c = keyCol(key);
-                resultLShapeCells.add(new int[]{c, r});
-            }
-
-            builder.addIsland(new SolverResult.Island(resultCells, resultLShapeCells, type));
+            builder.addIsland(island);
         }
 
         LOGGER.info("Solution: {} islands, {} harvest covered", bestSolution.size(), harvestCovered);

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -36,6 +36,8 @@ public class IslandFaceSolver implements FaceSolver {
     public static final byte SLIME = 1;
     public static final byte HONEY = 2;
 
+    private static final Comparator<Shape> SHAPE_PRIORITY_COMPARATOR = Comparator.comparingInt(Shape::onesCovered).reversed();
+
     // Grid state
     private byte[][] grid;
     private int rows;
@@ -145,7 +147,7 @@ public class IslandFaceSolver implements FaceSolver {
         ObjectSet<IntSet> seenShapesGlobal = new ObjectOpenHashSet<>();
 
         for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
-            possibleShapes.put(tIdx, new ObjectRBTreeSet<>(Comparator.comparingInt(Shape::onesCovered)));
+            possibleShapes.put(tIdx, new ObjectRBTreeSet<>(SHAPE_PRIORITY_COMPARATOR));
 
             int start = targets.getInt(tIdx);
 
@@ -192,7 +194,7 @@ public class IslandFaceSolver implements FaceSolver {
                     for (int key : newShape) {
                         int ti = targetIndices.get(key);
                         if (ti != -1) {
-                            possibleShapes.computeIfAbsent(ti, k -> new ObjectRBTreeSet<>(Comparator.comparingInt(Shape::onesCovered))).add(shape);
+                            possibleShapes.computeIfAbsent(ti, k -> new ObjectRBTreeSet<>(SHAPE_PRIORITY_COMPARATOR)).add(shape);
                         }
                     }
 

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -38,7 +38,6 @@ public class IslandFaceSolver implements FaceSolver {
     private byte[][] grid;
     private int rows;
     private int cols;
-    private int totalCells;
     private double islandCost;
     private long timeoutMs;
     private long startTime;
@@ -82,7 +81,7 @@ public class IslandFaceSolver implements FaceSolver {
 
         rows = input.width();
         cols = input.height();
-        totalCells = rows * cols;
+        int totalCells = rows * cols;
         grid = input.copyCells();
 
         // Initialize state
@@ -382,10 +381,6 @@ public class IslandFaceSolver implements FaceSolver {
         // Option: skip this target
         // There are no valid shapes that cover this target
         backtrack(sortedIdx + 1, currentIslands, slimeMask, honeyMask, lShapeStemMask, currentOnes, remainingPossibleTargets - 1, currentIslandsCount);
-    }
-
-    private boolean hasColor(byte colors, byte material) {
-        return (colors & (1 << material)) != 0;
     }
 
     private boolean isAdjacent(BitSet lShapeStemMask, LShape newLShape) {

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -1,5 +1,9 @@
 package pl.kosma.geodesy.solver;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +31,7 @@ public class IslandFaceSolver implements FaceSolver {
     private static final int MAX_SHAPES_PER_TARGET = 1000;
 
     // Grid state
-    private int[][] grid;
+    private byte[][] grid;
     private int rows;
     private int cols;
     private int totalCells;
@@ -37,10 +41,10 @@ public class IslandFaceSolver implements FaceSolver {
 
     // Target tracking
     private List<int[]> targets;  // List of [row, col] for all 1s
-    private Map<Long, Integer> targetIndices;  // Map cell key -> index in targets
+    private Long2IntOpenHashMap targetIndices;  // Map cell key -> index in targets
 
     // Precomputed shapes: Map target_index -> list of Shape
-    private Map<Integer, List<Shape>> possibleShapes;
+    private Int2ObjectOpenHashMap<List<Shape>> possibleShapes;
 
     // Sorted target indices (by scarcity - fewest shapes first)
     private int[] sortedTargetIndices;
@@ -54,9 +58,9 @@ public class IslandFaceSolver implements FaceSolver {
     private static class Shape {
         final BitSet mask;
         final int onesCovered;
-        final Set<Long> cells;
+        final LongOpenHashSet cells;
 
-        Shape(BitSet mask, int onesCovered, Set<Long> cells) {
+        Shape(BitSet mask, int onesCovered, LongOpenHashSet cells) {
             this.mask = mask;
             this.onesCovered = onesCovered;
             this.cells = cells;
@@ -64,11 +68,11 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     private static class Island {
-        final Set<Long> cells;
-        final Set<Long> lShapeCells;  // The 4 cells forming the L-shape
+        final LongOpenHashSet cells;
+        final LongOpenHashSet lShapeCells;  // The 4 cells forming the L-shape
         final int material;  // 0 = slime, 1 = honey
 
-        Island(Set<Long> cells, Set<Long> lShapeCells, int material) {
+        Island(LongOpenHashSet cells, LongOpenHashSet lShapeCells, int material) {
             this.cells = cells;
             this.lShapeCells = lShapeCells;
             this.material = material;
@@ -81,11 +85,11 @@ public class IslandFaceSolver implements FaceSolver {
         timeoutMs = config.getTimeoutMs();
         islandCost = config.getCostThreshold();
 
-        // Convert FaceGrid to internal grid format
+        // Convert FaceGrid to internal grid format (row-major, matching FaceGrid's storage)
         rows = input.getHeight();
         cols = input.getWidth();
         totalCells = rows * cols;
-        grid = new int[rows][cols];
+        grid = new byte[rows][cols];
 
         for (int y = 0; y < rows; y++) {
             for (int x = 0; x < cols; x++) {
@@ -95,8 +99,9 @@ public class IslandFaceSolver implements FaceSolver {
 
         // Initialize state
         targets = new ArrayList<>();
-        targetIndices = new HashMap<>();
-        possibleShapes = new HashMap<>();
+        targetIndices = new Long2IntOpenHashMap();
+        targetIndices.defaultReturnValue(-1);
+        possibleShapes = new Int2ObjectOpenHashMap<>();
         bestSolution = new ArrayList<>();
         maxScore = Double.NEGATIVE_INFINITY;
 
@@ -142,7 +147,7 @@ public class IslandFaceSolver implements FaceSolver {
         return row * cols + col;
     }
 
-    private BitSet getShapeMask(Set<Long> cells) {
+    private BitSet getShapeMask(LongOpenHashSet cells) {
         BitSet mask = new BitSet(totalCells);
         for (long key : cells) {
             int bit = cellBit(keyRow(key), keyCol(key));
@@ -152,7 +157,7 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     // An L-shape requires at least one cell to have neighbors in perpendicular directions.
-    private boolean hasLShape(Set<Long> cells) {
+    private boolean hasLShape(LongOpenHashSet cells) {
         for (long key : cells) {
             int r = keyRow(key);
             int c = keyCol(key);
@@ -191,7 +196,7 @@ public class IslandFaceSolver implements FaceSolver {
     private void precomputeShapes() {
         LOGGER.debug("Pre-computing shapes...");
 
-        Set<Set<Long>> seenShapesGlobal = new HashSet<>();
+        ObjectOpenHashSet<LongOpenHashSet> seenShapesGlobal = new ObjectOpenHashSet<>();
 
         for (int tIdx = 0; tIdx < targets.size(); tIdx++) {
             possibleShapes.put(tIdx, new ArrayList<>());
@@ -200,10 +205,11 @@ public class IslandFaceSolver implements FaceSolver {
             long startKey = cellKey(start[0], start[1]);
 
             // BFS to find shapes starting from this target
-            Queue<Set<Long>> queue = new LinkedList<>();
-            Set<Set<Long>> seenLocal = new HashSet<>();
+            // Use ArrayDeque as a deque: harvest neighbors go to front, air to back
+            ArrayDeque<LongOpenHashSet> queue = new ArrayDeque<>();
+            ObjectOpenHashSet<LongOpenHashSet> seenLocal = new ObjectOpenHashSet<>();
 
-            Set<Long> initial = new HashSet<>();
+            LongOpenHashSet initial = new LongOpenHashSet();
             initial.add(startKey);
             queue.add(initial);
             seenLocal.add(initial);
@@ -211,10 +217,10 @@ public class IslandFaceSolver implements FaceSolver {
             int shapesFound = 0;
 
             while (!queue.isEmpty() && shapesFound < MAX_SHAPES_PER_TARGET) {
-                Set<Long> current = queue.poll();
+                LongOpenHashSet current = queue.poll();
 
                 if (current.size() < MAX_ISLAND_SIZE) {
-                    Set<Long> neighbors = new HashSet<>();
+                    LongOpenHashSet neighbors = new LongOpenHashSet();
 
                     for (long key : current) {
                         int r = keyRow(key);
@@ -235,12 +241,20 @@ public class IslandFaceSolver implements FaceSolver {
                     }
 
                     for (long n : neighbors) {
-                        Set<Long> newShape = new HashSet<>(current);
+                        LongOpenHashSet newShape = new LongOpenHashSet(current);
                         newShape.add(n);
 
                         if (!seenLocal.contains(newShape)) {
                             seenLocal.add(newShape);
-                            queue.add(newShape);
+
+                            // Prioritize harvest-cell neighbors: add to front of queue
+                            int nr = keyRow(n);
+                            int nc = keyCol(n);
+                            if (grid[nr][nc] == FaceGrid.CELL_HARVEST) {
+                                queue.addFirst(newShape);
+                            } else {
+                                queue.addLast(newShape);
+                            }
 
                             if (newShape.size() >= MIN_ISLAND_SIZE && hasLShape(newShape)) {
                                 if (!seenShapesGlobal.contains(newShape)) {
@@ -256,12 +270,12 @@ public class IslandFaceSolver implements FaceSolver {
                                         }
                                     }
 
-                                    Shape shape = new Shape(mask, ones, new HashSet<>(newShape));
+                                    Shape shape = new Shape(mask, ones, new LongOpenHashSet(newShape));
 
                                     // Assign shape to every target it covers
                                     for (long key : newShape) {
-                                        Integer ti = targetIndices.get(key);
-                                        if (ti != null) {
+                                        int ti = targetIndices.get(key);
+                                        if (ti != -1) {
                                             possibleShapes.computeIfAbsent(ti, k -> new ArrayList<>()).add(shape);
                                         }
                                     }
@@ -303,8 +317,8 @@ public class IslandFaceSolver implements FaceSolver {
                 bestSolution = new ArrayList<>();
                 for (Island island : currentIslands) {
                     bestSolution.add(new Island(
-                            new HashSet<>(island.cells),
-                            new HashSet<>(island.lShapeCells),
+                            new LongOpenHashSet(island.cells),
+                            new LongOpenHashSet(island.lShapeCells),
                             island.material));
                 }
             }
@@ -341,56 +355,59 @@ public class IslandFaceSolver implements FaceSolver {
         shapes.sort((a, b) -> Integer.compare(b.onesCovered, a.onesCovered));
 
         for (Shape shape : shapes) {
-            if (!occupiedMask.intersects(shape.mask)) {
-                Set<Long> newLShape = findLShapeCells(shape.cells);
-                if (newLShape == null) continue;
+            if (occupiedMask.intersects(shape.mask)) continue;
 
-                Set<Integer> adjColors = new HashSet<>();
-                boolean possible = true;
+            LongOpenHashSet newLShape = findLShapeCells(shape.cells);
+            if (newLShape == null) continue;
 
-                for (Island existing : currentIslands) {
-                    // L-shapes of different islands cannot be adjacent
-                    if (isAdjacent(newLShape, existing.lShapeCells)) {
+            Set<Integer> adjColors = new HashSet<>();
+            boolean possible = true;
+
+            for (Island existing : currentIslands) {
+                // L-shapes contain the flying machine mechanism (pistons + slime/honey).
+                // Even though adjacent islands use different materials, adjacent L-shapes
+                // would cause mechanical interference during piston extension — the
+                // flying machines would push/pull each other's components.
+                if (isAdjacent(newLShape, existing.lShapeCells)) {
+                    possible = false;
+                    break;
+                }
+
+                // Adjacent islands must have different colors
+                if (isAdjacent(shape.cells, existing.cells)) {
+                    adjColors.add(existing.material);
+                    if (adjColors.size() >= 2) {
                         possible = false;
                         break;
                     }
-
-                    // Adjacent islands must have different colors
-                    if (isAdjacent(shape.cells, existing.cells)) {
-                        adjColors.add(existing.material);
-                        if (adjColors.size() >= 2) {
-                            possible = false;
-                            break;
-                        }
-                    }
-                }
-
-                if (possible) {
-                    int color = adjColors.contains(0) ? 1 : 0;
-
-                    currentIslands.add(new Island(shape.cells, newLShape, color));
-
-                    BitSet newOccupied = (BitSet) occupiedMask.clone();
-                    newOccupied.or(shape.mask);
-
-                    backtrack(
-                            sortedIdx + 1,
-                            newOccupied,
-                            currentIslands,
-                            currentOnes + shape.onesCovered,
-                            currentIslandsCount + 1
-                    );
-
-                    currentIslands.remove(currentIslands.size() - 1);
                 }
             }
+
+            if (!possible) continue;
+
+            int color = adjColors.contains(0) ? 1 : 0;
+
+            currentIslands.add(new Island(shape.cells, newLShape, color));
+
+            BitSet newOccupied = (BitSet) occupiedMask.clone();
+            newOccupied.or(shape.mask);
+
+            backtrack(
+                    sortedIdx + 1,
+                    newOccupied,
+                    currentIslands,
+                    currentOnes + shape.onesCovered,
+                    currentIslandsCount + 1
+            );
+
+            currentIslands.remove(currentIslands.size() - 1);
         }
 
         // Option: skip this target
         backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
     }
 
-    private boolean isAdjacent(Set<Long> cells1, Set<Long> cells2) {
+    private boolean isAdjacent(LongOpenHashSet cells1, LongOpenHashSet cells2) {
         for (long key : cells1) {
             int r = keyRow(key);
             int c = keyCol(key);
@@ -404,7 +421,7 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
-    private Set<Long> findLShapeCells(Set<Long> cells) {
+    private LongOpenHashSet findLShapeCells(LongOpenHashSet cells) {
         for (long key : cells) {
             int x = keyRow(key);
             int y = keyCol(key);
@@ -429,7 +446,7 @@ public class IslandFaceSolver implements FaceSolver {
                         long cornerKey = cellKey(cornerX, cornerY);
 
                         if (cells.contains(cornerKey)) {
-                            Set<Long> lShape = new HashSet<>();
+                            LongOpenHashSet lShape = new LongOpenHashSet();
                             lShape.add(prevKey);
                             lShape.add(key);
                             lShape.add(nextKey);
@@ -443,7 +460,7 @@ public class IslandFaceSolver implements FaceSolver {
                         cornerKey = cellKey(cornerX, cornerY);
 
                         if (cells.contains(cornerKey)) {
-                            Set<Long> lShape = new HashSet<>();
+                            LongOpenHashSet lShape = new LongOpenHashSet();
                             lShape.add(prevKey);
                             lShape.add(key);
                             lShape.add(nextKey);
@@ -463,7 +480,7 @@ public class IslandFaceSolver implements FaceSolver {
                 .solveTimeMs(solveTime)
                 .timedOut(timedOut);
 
-        Set<Long> coveredCells = new HashSet<>();
+        LongOpenHashSet coveredCells = new LongOpenHashSet();
         for (Island island : bestSolution) {
             coveredCells.addAll(island.cells);
         }
@@ -492,11 +509,18 @@ public class IslandFaceSolver implements FaceSolver {
                 resultCells.add(new int[]{c, r});
             }
 
-            builder.addIsland(new SolverResult.Island(resultCells, type));
+            // Convert internal L-shape cells to [x, y] coordinates for SolverResult
+            Set<int[]> resultLShapeCells = new HashSet<>();
+            for (long key : island.lShapeCells) {
+                int r = keyRow(key);
+                int c = keyCol(key);
+                resultLShapeCells.add(new int[]{c, r});
+            }
+
+            builder.addIsland(new SolverResult.Island(resultCells, resultLShapeCells, type));
         }
 
-        LOGGER.info("Solution: {} islands, {} harvest covered, score={:.2f}",
-                bestSolution.size(), harvestCovered, maxScore);
+        LOGGER.info("Solution: {} islands, {} harvest covered", bestSolution.size(), harvestCovered);
 
         return builder.build();
     }

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -80,9 +80,8 @@ public class IslandFaceSolver implements FaceSolver {
         timeoutMs = config.getTimeoutMs();
         islandCost = config.getCostThreshold();
 
-        // Convert FaceGrid to internal grid format (row-major, matching FaceGrid's storage)
-        rows = input.getHeight();
-        cols = input.getWidth();
+        rows = input.getWidth();
+        cols = input.getHeight();
         totalCells = rows * cols;
         grid = input.copyCells();
 
@@ -110,7 +109,7 @@ public class IslandFaceSolver implements FaceSolver {
             return SolverResult.empty(input);
         }
 
-        LOGGER.info("Solving {}x{} grid with {} harvest cells", cols, rows, targets.size());
+        LOGGER.info("Solving {}x{} grid with {} harvest cells", rows, cols, targets.size());
 
         precomputeShapes();
         backtrack(0, new BitSet(totalCells), new ArrayList<>(), 0, 0);
@@ -475,8 +474,8 @@ public class IslandFaceSolver implements FaceSolver {
             for (int key : island.cells) {
                 int r = keyRow(key);
                 int c = keyCol(key);
-                // FaceGrid uses (x, y) where x=col, y=row
-                builder.setPlacement(c, r, island.material);
+                // FaceGrid uses (x, y) where x=row, y=col
+                builder.setPlacement(r, c, island.material);
             }
 
             builder.addIsland(island);

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -1,9 +1,8 @@
 package pl.kosma.geodesy.solver;
 
-import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
-import it.unimi.dsi.fastutil.bytes.ByteSet;
 import it.unimi.dsi.fastutil.ints.*;
-import it.unimi.dsi.fastutil.objects.*;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +61,7 @@ public class IslandFaceSolver implements FaceSolver {
     // Underflow will impact the upper 16 bits, but we rely on range checks on the lower 16 bits to catch that.
     private static final int[] DIRECTIONS = {cellKey(0, 1), -1, cellKey(1, 0), cellKey(-1, 0)};
 
-    private record Shape(BitSet mask, int onesCovered, IntSet cells) {}
+    private record Shape(BitSet mask, int onesCovered, IntSet cells, LShape lShape) {}
 
     /**
      * @param material    1 = slime, 2 = honey
@@ -183,10 +182,15 @@ public class IslandFaceSolver implements FaceSolver {
                         queueAir.add(newShape);
                     }
 
-                    if (newShape.size() < MIN_ISLAND_SIZE || !hasLShape(newShape) || !seenShapesGlobal.add(newShape)) continue;
+                    if (newShape.size() < MIN_ISLAND_SIZE) continue;
+
+                    LShape lShape = findLShapeCells(newShape);
+                    if (lShape == null) continue;
+
+                    if (!seenShapesGlobal.add(newShape)) continue;
 
                     // We have not seen this shape globally
-                    Shape shape = createShape(newShape);
+                    Shape shape = createShape(newShape, lShape);
 
                     // Assign shape to every target it covers
                     for (int key : newShape) {
@@ -221,44 +225,37 @@ public class IslandFaceSolver implements FaceSolver {
         return neighbors;
     }
 
-    // An L-shape requires at least one cell to have neighbors in perpendicular directions.
-    private boolean hasLShape(IntSet cells) {
+    // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
+    private static LShape findLShapeCells(IntSet cells) {
         for (int key : cells) {
-            int r = keyRow(key);
-            int c = keyCol(key);
+            for (int stemDir : DIRECTIONS) {
+                int prevKey = key - stemDir;
+                int nextKey = key + stemDir;
 
-            // Check for horizontal line segment (3 cells)
-            boolean hasLeft = cells.contains(cellKey(r, c - 1));
-            boolean hasRight = cells.contains(cellKey(r, c + 1));
+                if (cells.contains(prevKey) && cells.contains(nextKey)) {
+                    for (int perpDir : DIRECTIONS) {
+                        // Black magic with packed shorts
+                        if (perpDir == stemDir || perpDir == -stemDir) continue;
 
-            if (hasLeft && hasRight) {
-                for (int dr : new int[]{-1, 1}) {
-                    for (int dc = -1; dc <= 1; dc++) {
-                        if (cells.contains(cellKey(r + dr, c + dc))) {
-                            return true;
+                        // Check corner at prev end
+                        int cornerKey = prevKey + perpDir;
+                        if (cells.contains(cornerKey)) {
+                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }
-                    }
-                }
-            }
 
-            // Check for vertical line segment (3 cells)
-            boolean hasUp = cells.contains(cellKey(r - 1, c));
-            boolean hasDown = cells.contains(cellKey(r + 1, c));
-
-            if (hasUp && hasDown) {
-                for (int dr = -1; dr <= 1; dr++) {
-                    for (int dc : new int[]{-1, 1}) {
-                        if (cells.contains(cellKey(r + dr, c + dc))) {
-                            return true;
+                        // Check corner at next end
+                        cornerKey = nextKey + perpDir;
+                        if (cells.contains(cornerKey)) {
+                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }
                     }
                 }
             }
         }
-        return false;
+        return null;
     }
 
-    private Shape createShape(IntSet newShape) {
+    private Shape createShape(IntSet newShape, LShape lShape) {
         BitSet mask = new BitSet(totalCells);
         int ones = 0;
 
@@ -274,7 +271,7 @@ public class IslandFaceSolver implements FaceSolver {
             }
         }
 
-        return new Shape(mask, ones, newShape);
+        return new Shape(mask, ones, newShape, lShape);
     }
 
     private void sortShapes() {
@@ -334,10 +331,7 @@ public class IslandFaceSolver implements FaceSolver {
         for (Shape shape : shapes) {
             if (occupiedMask.intersects(shape.mask)) continue;
 
-            LShape newLShape = findLShapeCells(shape.cells);
-            if (newLShape == null) continue;
-
-            ByteSet adjColors = new ByteOpenHashSet();
+            byte adjColors = 0;
             boolean possible = true;
 
             for (Island existing : currentIslands) {
@@ -345,15 +339,15 @@ public class IslandFaceSolver implements FaceSolver {
                 // Even though adjacent islands use different materials, adjacent L-shapes
                 // would cause mechanical interference during piston extension — the
                 // flying machines would push/pull each other's components.
-                if (isAdjacent(newLShape, existing.lShape)) {
+                if (isAdjacent(shape.lShape, existing.lShape)) {
                     possible = false;
                     break;
                 }
 
                 // Adjacent islands must have different colors
                 if (isAdjacent(shape.cells, existing.cells)) {
-                    adjColors.add(existing.material);
-                    if (adjColors.size() >= 2) {
+                    adjColors |= (byte) (1 << existing.material);
+                    if (hasColor(adjColors, SLIME) && hasColor(adjColors, HONEY)) {
                         possible = false;
                         break;
                     }
@@ -362,9 +356,9 @@ public class IslandFaceSolver implements FaceSolver {
 
             if (!possible) continue;
 
-            byte color = adjColors.contains(SLIME) ? HONEY : SLIME;
+            byte color = hasColor(adjColors, SLIME) ? HONEY : SLIME;
 
-            currentIslands.add(new Island(shape.cells, newLShape, color));
+            currentIslands.add(new Island(shape.cells, shape.lShape, color));
 
             BitSet newOccupied = (BitSet) occupiedMask.clone();
             newOccupied.or(shape.mask);
@@ -384,6 +378,10 @@ public class IslandFaceSolver implements FaceSolver {
         backtrack(sortedIdx + 1, occupiedMask, currentIslands, currentOnes, currentIslandsCount);
     }
 
+    private boolean hasColor(byte colors, byte material) {
+        return (colors & (1 << material)) != 0;
+    }
+
     private boolean isAdjacent(LShape cells1, LShape cells2) {
         return isAdjacent(cells1.stemCells, cells2.stemCells);
     }
@@ -397,36 +395,6 @@ public class IslandFaceSolver implements FaceSolver {
             }
         }
         return false;
-    }
-
-    // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
-    private LShape findLShapeCells(IntSet cells) {
-        for (int key : cells) {
-            for (int stemDir : DIRECTIONS) {
-                int prevKey = key - stemDir;
-                int nextKey = key + stemDir;
-
-                if (cells.contains(prevKey) && cells.contains(nextKey)) {
-                    for (int perpDir : DIRECTIONS) {
-                        // Black magic with packed shorts
-                        if (perpDir == stemDir || perpDir == -stemDir) continue;
-
-                        // Check corner at prev end
-                        int cornerKey = prevKey + perpDir;
-                        if (cells.contains(cornerKey)) {
-                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
-                        }
-
-                        // Check corner at next end
-                        cornerKey = nextKey + perpDir;
-                        if (cells.contains(cornerKey)) {
-                            return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
-                        }
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     private SolverResult buildResult(FaceGrid input, long solveTime, boolean timedOut) {

--- a/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
+++ b/src/main/java/pl/kosma/geodesy/solver/IslandFaceSolver.java
@@ -59,7 +59,9 @@ public class IslandFaceSolver implements FaceSolver {
     private List<Island> bestSolution;
     private double maxScore;
 
-    private static final int[][] DIRECTIONS = {{0, 1}, {0, -1}, {1, 0}, {-1, 0}};
+    // Special processing for subtracting 1 from the lower 16 bits.
+    // Underflow will impact the upper 16 bits, but we rely on range checks on the lower 16 bits to catch that.
+    private static final int[] DIRECTIONS = {cellKey(0, 1), -1, cellKey(1, 0), cellKey(-1, 0)};
 
     private record Shape(BitSet mask, int onesCovered, IntSet cells) {}
 
@@ -129,7 +131,8 @@ public class IslandFaceSolver implements FaceSolver {
     }
 
     public static int keyCol(int key) {
-        return key & 0xFFFF;
+        // This interprets the 16th bit as the sign bit
+        return key << 16 >> 16;
     }
 
     private int cellBit(int row, int col) {
@@ -216,15 +219,13 @@ public class IslandFaceSolver implements FaceSolver {
         IntSet neighbors = new IntOpenHashSet();
 
         for (int key : current) {
-            int r = keyRow(key);
-            int c = keyCol(key);
-
-            for (int[] dir : DIRECTIONS) {
-                int nr = r + dir[0];
-                int nc = c + dir[1];
+            for (int dir : DIRECTIONS) {
+                int nkey = key + dir;
+                int nr = keyRow(nkey);
+                int nc = keyCol(nkey);
 
                 if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && grid[nr][nc] != FaceGrid.CELL_BLOCKED) {
-                    neighbors.add(cellKey(nr, nc));
+                    neighbors.add(nkey);
                 }
             }
         }
@@ -394,10 +395,8 @@ public class IslandFaceSolver implements FaceSolver {
 
     private boolean isAdjacent(IntSet cells1, IntSet cells2) {
         for (int key : cells1) {
-            int r = keyRow(key);
-            int c = keyCol(key);
-            for (int[] dir : DIRECTIONS) {
-                if (cells2.contains(cellKey(r + dir[0], c + dir[1]))) {
+            for (int dir : DIRECTIONS) {
+                if (cells2.contains(key + dir)) {
                     return true;
                 }
             }
@@ -408,37 +407,23 @@ public class IslandFaceSolver implements FaceSolver {
     // Finds the L-shape cells (4 cells: 3 in a row + 1 perpendicular).
     private LShape findLShapeCells(IntSet cells) {
         for (int key : cells) {
-            int x = keyRow(key);
-            int y = keyCol(key);
-
-            for (int[] stemDir : DIRECTIONS) {
-                int prevX = x - stemDir[0];
-                int prevY = y - stemDir[1];
-                int nextX = x + stemDir[0];
-                int nextY = y + stemDir[1];
-
-                int prevKey = cellKey(prevX, prevY);
-                int nextKey = cellKey(nextX, nextY);
+            for (int stemDir : DIRECTIONS) {
+                int prevKey = key - stemDir;
+                int nextKey = key + stemDir;
 
                 if (cells.contains(prevKey) && cells.contains(nextKey)) {
-                    for (int[] perpDir : DIRECTIONS) {
-                        if (perpDir[0] == stemDir[0] && perpDir[1] == stemDir[1]) continue;
-                        if (perpDir[0] == -stemDir[0] && perpDir[1] == -stemDir[1]) continue;
+                    for (int perpDir : DIRECTIONS) {
+                        // Black magic with packed shorts
+                        if (perpDir == stemDir || perpDir == -stemDir) continue;
 
                         // Check corner at prev end
-                        int cornerX = prevX + perpDir[0];
-                        int cornerY = prevY + perpDir[1];
-                        int cornerKey = cellKey(cornerX, cornerY);
-
+                        int cornerKey = prevKey + perpDir;
                         if (cells.contains(cornerKey)) {
                             return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }
 
                         // Check corner at next end
-                        cornerX = nextX + perpDir[0];
-                        cornerY = nextY + perpDir[1];
-                        cornerKey = cellKey(cornerX, cornerY);
-
+                        cornerKey = nextKey + perpDir;
                         if (cells.contains(cornerKey)) {
                             return new LShape(IntSet.of(prevKey, key, nextKey), cornerKey);
                         }

--- a/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
@@ -1,0 +1,65 @@
+package pl.kosma.geodesy.solver;
+
+/**
+ * Configuration parameters for the face solver algorithm.
+ */
+public class SolverConfig {
+
+    public static final long DEFAULT_TIMEOUT_MS = 5_000L;
+    public static final double DEFAULT_COST_THRESHOLD = 1.0;
+    // Below 1.0, islands covering only 1 harvest cell would still be "profitable".
+    public static final double MIN_COST_THRESHOLD = 1.0;
+    // Above 12.0 (max island size), even a fully productive island would be penalized out.
+    public static final double MAX_COST_THRESHOLD = 12.0;
+
+    private final long timeoutMs;
+    private final double costThreshold;
+
+    private SolverConfig(Builder builder) {
+        this.timeoutMs = builder.timeoutMs;
+        this.costThreshold = builder.costThreshold;
+    }
+
+    public long getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public double getCostThreshold() {
+        return costThreshold;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static SolverConfig defaults() {
+        return builder().build();
+    }
+
+    @Override
+    public String toString() {
+        return "SolverConfig[timeoutMs=" + timeoutMs + ", costThreshold=" + costThreshold + "]";
+    }
+
+    public static class Builder {
+        private long timeoutMs = DEFAULT_TIMEOUT_MS;
+        private double costThreshold = DEFAULT_COST_THRESHOLD;
+
+        private Builder() {}
+
+        public Builder timeoutMs(long timeoutMs) {
+            this.timeoutMs = timeoutMs;
+            return this;
+        }
+
+        // Value is clamped to [MIN_COST_THRESHOLD, MAX_COST_THRESHOLD].
+        public Builder costThreshold(double costThreshold) {
+            this.costThreshold = Math.max(MIN_COST_THRESHOLD, Math.min(MAX_COST_THRESHOLD, costThreshold));
+            return this;
+        }
+
+        public SolverConfig build() {
+            return new SolverConfig(this);
+        }
+    }
+}

--- a/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
@@ -54,7 +54,7 @@ public class SolverConfig {
 
         // Value is clamped to [MIN_COST_THRESHOLD, MAX_COST_THRESHOLD].
         public Builder costThreshold(double costThreshold) {
-            this.costThreshold = Math.max(MIN_COST_THRESHOLD, Math.min(MAX_COST_THRESHOLD, costThreshold));
+            this.costThreshold = Math.clamp(costThreshold, MIN_COST_THRESHOLD, MAX_COST_THRESHOLD);
             return this;
         }
 

--- a/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverConfig.java
@@ -5,7 +5,7 @@ package pl.kosma.geodesy.solver;
  */
 public class SolverConfig {
 
-    public static final long DEFAULT_TIMEOUT_MS = 5_000L;
+    public static final long DEFAULT_TIMEOUT_MS = 10_000L;
     public static final double DEFAULT_COST_THRESHOLD = 1.0;
     // Below 1.0, islands covering only 1 harvest cell would still be "profitable".
     public static final double MIN_COST_THRESHOLD = 1.0;

--- a/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
@@ -1,0 +1,194 @@
+package pl.kosma.geodesy.solver;
+
+import net.minecraft.util.math.Direction;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents the result of solving a single face.
+ * Contains placement instructions (NONE, SLIME, HONEY) for each cell.
+ */
+public class SolverResult {
+
+    public enum PlacementType {
+        NONE,
+        SLIME,
+        HONEY
+    }
+
+    /**
+     * Represents an island (connected group of cells) in the solution.
+     */
+    public static class Island {
+        private final Set<int[]> cells;  // Set of [x, y] coordinates
+        private final PlacementType material;
+
+        public Island(Set<int[]> cells, PlacementType material) {
+            this.cells = cells;
+            this.material = material;
+        }
+
+        public Set<int[]> getCells() {
+            return cells;
+        }
+
+        public PlacementType getMaterial() {
+            return material;
+        }
+    }
+
+    private final int width;
+    private final int height;
+    private final Direction direction;
+    private final PlacementType[][] placements;
+    private final List<Island> islands;
+    private final int harvestCovered;
+    private final int totalHarvest;
+    private final long solveTimeMs;
+    private final boolean timedOut;
+
+    private SolverResult(Builder builder) {
+        this.width = builder.width;
+        this.height = builder.height;
+        this.direction = builder.direction;
+        this.placements = builder.placements;
+        this.islands = new ArrayList<>(builder.islands);
+        this.harvestCovered = builder.harvestCovered;
+        this.totalHarvest = builder.totalHarvest;
+        this.solveTimeMs = builder.solveTimeMs;
+        this.timedOut = builder.timedOut;
+    }
+
+    public PlacementType getPlacement(int x, int y) {
+        return placements[x][y];
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    public List<Island> getIslands() {
+        return Collections.unmodifiableList(islands);
+    }
+
+    public int getHarvestCovered() {
+        return harvestCovered;
+    }
+
+    public int getTotalHarvest() {
+        return totalHarvest;
+    }
+
+    public float getCoveragePercent() {
+        if (totalHarvest == 0) return 100.0f;
+        return 100.0f * harvestCovered / totalHarvest;
+    }
+
+    public long getSolveTimeMs() {
+        return solveTimeMs;
+    }
+
+    public boolean isTimedOut() {
+        return timedOut;
+    }
+
+    public int getBlockCount() {
+        int count = 0;
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (placements[x][y] != PlacementType.NONE) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public static Builder builder(int width, int height, Direction direction) {
+        return new Builder(width, height, direction);
+    }
+
+    public static SolverResult empty(FaceGrid input) {
+        return builder(input.getWidth(), input.getHeight(), input.getDirection())
+                .totalHarvest(input.getHarvestCount())
+                .harvestCovered(0)
+                .solveTimeMs(0)
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SolverResult[%dx%d, direction=%s, coverage=%.1f%% (%d/%d), blocks=%d, time=%dms%s]",
+                width, height, direction, getCoveragePercent(), harvestCovered, totalHarvest,
+                getBlockCount(), solveTimeMs, timedOut ? ", TIMED OUT" : "");
+    }
+
+    public static class Builder {
+        private final int width;
+        private final int height;
+        private final Direction direction;
+        private final PlacementType[][] placements;
+        private final List<Island> islands = new ArrayList<>();
+        private int harvestCovered = 0;
+        private int totalHarvest = 0;
+        private long solveTimeMs = 0;
+        private boolean timedOut = false;
+
+        private Builder(int width, int height, Direction direction) {
+            this.width = width;
+            this.height = height;
+            this.direction = direction;
+            this.placements = new PlacementType[width][height];
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    placements[x][y] = PlacementType.NONE;
+                }
+            }
+        }
+
+        public Builder setPlacement(int x, int y, PlacementType type) {
+            placements[x][y] = type;
+            return this;
+        }
+
+        public Builder addIsland(Island island) {
+            islands.add(island);
+            return this;
+        }
+
+        public Builder harvestCovered(int count) {
+            this.harvestCovered = count;
+            return this;
+        }
+
+        public Builder totalHarvest(int count) {
+            this.totalHarvest = count;
+            return this;
+        }
+
+        public Builder solveTimeMs(long timeMs) {
+            this.solveTimeMs = timeMs;
+            return this;
+        }
+
+        public Builder timedOut(boolean timedOut) {
+            this.timedOut = timedOut;
+            return this;
+        }
+
+        public SolverResult build() {
+            return new SolverResult(this);
+        }
+    }
+}

--- a/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
@@ -24,15 +24,21 @@ public class SolverResult {
      */
     public static class Island {
         private final Set<int[]> cells;  // Set of [x, y] coordinates
+        private final Set<int[]> lShapeCells;  // The 4 cells forming the L-shape (3 stem + 1 corner)
         private final PlacementType material;
 
-        public Island(Set<int[]> cells, PlacementType material) {
+        public Island(Set<int[]> cells, Set<int[]> lShapeCells, PlacementType material) {
             this.cells = cells;
+            this.lShapeCells = lShapeCells;
             this.material = material;
         }
 
         public Set<int[]> getCells() {
             return cells;
+        }
+
+        public Set<int[]> getLShapeCells() {
+            return lShapeCells;
         }
 
         public PlacementType getMaterial() {

--- a/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
@@ -10,69 +10,21 @@ import java.util.List;
  * Represents the result of solving a single face.
  * Contains placement instructions (NONE, SLIME, HONEY) for each cell.
  */
-public class SolverResult {
-
-    private final int width;
-    private final int height;
-    private final Direction direction;
-    private final byte[][] placements;
-    private final List<IslandFaceSolver.Island> islands;
-    private final int harvestCovered;
-    private final int totalHarvest;
-    private final long solveTimeMs;
-    private final boolean timedOut;
+public record SolverResult(int width, int height, Direction direction,
+                           byte[][] placements, List<IslandFaceSolver.Island> islands,
+                           int harvestCovered, int totalHarvest, long solveTimeMs, boolean timedOut) {
 
     private SolverResult(Builder builder) {
-        this.width = builder.width;
-        this.height = builder.height;
-        this.direction = builder.direction;
-        this.placements = builder.placements;
-        this.islands = new ArrayList<>(builder.islands);
-        this.harvestCovered = builder.harvestCovered;
-        this.totalHarvest = builder.totalHarvest;
-        this.solveTimeMs = builder.solveTimeMs;
-        this.timedOut = builder.timedOut;
+        this(builder.width, builder.height, builder.direction, builder.placements, Collections.unmodifiableList(builder.islands), builder.harvestCovered, builder.totalHarvest, builder.solveTimeMs, builder.timedOut);
     }
 
     public byte getPlacement(int x, int y) {
         return placements[x][y];
     }
 
-    public int getWidth() {
-        return width;
-    }
-
-    public int getHeight() {
-        return height;
-    }
-
-    public Direction getDirection() {
-        return direction;
-    }
-
-    public List<IslandFaceSolver.Island> getIslands() {
-        return Collections.unmodifiableList(islands);
-    }
-
-    public int getHarvestCovered() {
-        return harvestCovered;
-    }
-
-    public int getTotalHarvest() {
-        return totalHarvest;
-    }
-
     public float getCoveragePercent() {
         if (totalHarvest == 0) return 100.0f;
         return 100.0f * harvestCovered / totalHarvest;
-    }
-
-    public long getSolveTimeMs() {
-        return solveTimeMs;
-    }
-
-    public boolean isTimedOut() {
-        return timedOut;
     }
 
     public int getBlockCount() {
@@ -92,7 +44,7 @@ public class SolverResult {
     }
 
     public static SolverResult empty(FaceGrid input) {
-        return builder(input.getWidth(), input.getHeight(), input.getDirection())
+        return builder(input.width(), input.height(), input.direction())
                 .totalHarvest(input.getHarvestCount())
                 .harvestCovered(0)
                 .solveTimeMs(0)

--- a/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
+++ b/src/main/java/pl/kosma/geodesy/solver/SolverResult.java
@@ -5,7 +5,6 @@ import net.minecraft.util.math.Direction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Represents the result of solving a single face.
@@ -13,44 +12,11 @@ import java.util.Set;
  */
 public class SolverResult {
 
-    public enum PlacementType {
-        NONE,
-        SLIME,
-        HONEY
-    }
-
-    /**
-     * Represents an island (connected group of cells) in the solution.
-     */
-    public static class Island {
-        private final Set<int[]> cells;  // Set of [x, y] coordinates
-        private final Set<int[]> lShapeCells;  // The 4 cells forming the L-shape (3 stem + 1 corner)
-        private final PlacementType material;
-
-        public Island(Set<int[]> cells, Set<int[]> lShapeCells, PlacementType material) {
-            this.cells = cells;
-            this.lShapeCells = lShapeCells;
-            this.material = material;
-        }
-
-        public Set<int[]> getCells() {
-            return cells;
-        }
-
-        public Set<int[]> getLShapeCells() {
-            return lShapeCells;
-        }
-
-        public PlacementType getMaterial() {
-            return material;
-        }
-    }
-
     private final int width;
     private final int height;
     private final Direction direction;
-    private final PlacementType[][] placements;
-    private final List<Island> islands;
+    private final byte[][] placements;
+    private final List<IslandFaceSolver.Island> islands;
     private final int harvestCovered;
     private final int totalHarvest;
     private final long solveTimeMs;
@@ -68,7 +34,7 @@ public class SolverResult {
         this.timedOut = builder.timedOut;
     }
 
-    public PlacementType getPlacement(int x, int y) {
+    public byte getPlacement(int x, int y) {
         return placements[x][y];
     }
 
@@ -84,7 +50,7 @@ public class SolverResult {
         return direction;
     }
 
-    public List<Island> getIslands() {
+    public List<IslandFaceSolver.Island> getIslands() {
         return Collections.unmodifiableList(islands);
     }
 
@@ -113,7 +79,7 @@ public class SolverResult {
         int count = 0;
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                if (placements[x][y] != PlacementType.NONE) {
+                if (placements[x][y] != 0) {
                     count++;
                 }
             }
@@ -144,8 +110,8 @@ public class SolverResult {
         private final int width;
         private final int height;
         private final Direction direction;
-        private final PlacementType[][] placements;
-        private final List<Island> islands = new ArrayList<>();
+        private final byte[][] placements;
+        private final List<IslandFaceSolver.Island> islands = new ArrayList<>();
         private int harvestCovered = 0;
         private int totalHarvest = 0;
         private long solveTimeMs = 0;
@@ -155,20 +121,15 @@ public class SolverResult {
             this.width = width;
             this.height = height;
             this.direction = direction;
-            this.placements = new PlacementType[width][height];
-            for (int x = 0; x < width; x++) {
-                for (int y = 0; y < height; y++) {
-                    placements[x][y] = PlacementType.NONE;
-                }
-            }
+            this.placements = new byte[width][height];
         }
 
-        public Builder setPlacement(int x, int y, PlacementType type) {
+        public Builder setPlacement(int x, int y, byte type) {
             placements[x][y] = type;
             return this;
         }
 
-        public Builder addIsland(Island island) {
+        public Builder addIsland(IslandFaceSolver.Island island) {
             islands.add(island);
             return this;
         }


### PR DESCRIPTION
# Add `/geodesy solve` command for automatic flying machine layout

## Summary

This PR adds a new `/geodesy solve` command that automatically calculates optimal slime/honey block placement and mob head markers after running `/geodesy project`. This eliminates the tedious manual process of figuring out island layouts.

**Before:** Manual placement of sticky blocks and mob heads (Steps 5-6 in the old workflow)
**After:** Run `/geodesy solve` and it's done automatically

## Usage

```
/geodesy solve                    # Default: 5s timeout, cost=1.0
/geodesy solve <timeout>          # Custom timeout (1-300 seconds)
/geodesy solve <timeout> <cost>   # Custom timeout and cost (1.0-12.0)
```

The **cost** parameter controls the coverage vs. machine count tradeoff:
- `cost=1.0` → More machines, higher coverage
- `cost=4.0` → Fewer machines, may skip some pumpkins

## Algorithm Overview

The solver finds optimal "islands" (connected groups of 4-12 blocks) to cover harvest cells.

### Constraints

```
┌─────────────────────────────────────────────────┐
│  1. Islands must be 4-12 blocks                 │
│  2. Each island must contain an L-shape         │
│  3. Adjacent islands must alternate materials   │
│  4. L-shapes of different islands can't touch   │
│  5. Islands can't cover blocked cells           │
└─────────────────────────────────────────────────┘
```

### Valid L-Shape Examples

```
  ██░      ░██      ██░░
  ░░░      ░░░      ░░░░
  ░░░      ░░░      ░░░░

  "L"    "reverse"  "extended"
```

### Two-Coloring for Adjacent Islands

```
   SSSSS          S = Slime
   S   HHHH       H = Honey
   S   H
   S   H          Adjacent islands must use
       H          different materials!
```

### Algorithm Steps

1. **Precompute shapes:** BFS from each harvest cell to find all valid island shapes (4-12 cells with L-shape)
2. **Sort by scarcity:** Process harvest cells with fewest possible shapes first (better pruning)
3. **Backtrack:** Try placing islands, checking constraints, track best solution
4. **Score:** `harvest_covered - (island_count × cost)`

### Optimization

- Faces are solved **in parallel** using a thread pool
- BitSet for O(1) overlap detection
- Early pruning when remaining cells can't beat current best

## Files Changed

| File | Change |
|------|--------|
| `solver/IslandFaceSolver.java` | New - Core algorithm |
| `solver/FaceGrid.java` | New - Input representation |
| `solver/SolverResult.java` | New - Output with islands |
| `solver/SolverConfig.java` | New - Timeout/cost config |
| `GeodesyCore.java` | Added `geodesySolve()` + helpers |
| `GeodesyFabricMod.java` | Registered command |
| `README.md` | Documentation |

## Example Output

```
Solving 3 face(s) in parallel...
  EAST: 85% coverage (17/20), 24 blocks, 1243ms
  SOUTH: 100% coverage (15/15), 20 blocks, 892ms
  UP: 92% coverage (11/12), 16 blocks, 456ms
Solve complete. Run /geodesy assemble when ready.
```
